### PR TITLE
Run tests on latest stable Bun version

### DIFF
--- a/.github/workflows/js-sdk-ci.yml
+++ b/.github/workflows/js-sdk-ci.yml
@@ -104,11 +104,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        bun-version: ["1.1.0", "1.1.34"]
+        bun-version: ["1.1.0", "latest"]
          # Bun fails to run tests on ubuntu-latest and macOS-latest.
          # It may not be possible at all for now: https://github.com/oven-sh/bun/issues/10001
-         # Bun version "latest" (1.1.36) seems to have a regression,
-         # so we use 1.1.34 until it fixed.
         os: [windows-latest]
     name: Bun ${{ matrix.bun-version }} (${{ matrix.os }}) test
     steps:

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The SDK is [tested](https://github.com/configcat/js-unified-sdk/blob/master/.git
   - Chromium (64.0.3282.0, 72.0.3626.0, 80.0.3987.0)
   - Firefox (latest, latest-beta, 84.0)
 - @configcat/sdk/bun:
-  - Bun (v1.1.0, v1.1.34) on Windows
+  - Bun (v1.1.0, latest stable) on Windows
 - @configcat/sdk/deno:
   - Deno (v1.31, v1.46, latest stable) on Windows / Ubuntu / macOS
 - @configcat/sdk/node:


### PR DESCRIPTION
### Describe the purpose of your pull request

Bun [introduced a bug in v1.35](https://github.com/oven-sh/bun/issues/15326) which caused our tests to fail. [They've fixed it](https://bun.sh/blog/bun-v1.1.37#regression-in-printing-uffff) so we can run the tests against the latest Bun version again.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
