### PR TITLE
Fix failing setup of GitHub Actions checks

### DIFF
--- a/.github/workflows/js-sdk-ci.yml
+++ b/.github/workflows/js-sdk-ci.yml
@@ -29,7 +29,9 @@ jobs:
         run: npm run check:ts-compat
 
   test-browser-chrome:
-    runs-on: ubuntu-latest
+    # Runner image version is temporarily pinned to `ubuntu-22.04`.
+    # TODO: Restore it to `ubuntu-latest` as soon as compatibility issues with `browser-actions/setup-chrome@latest` are sorted out.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         chrome: ["beta", "stable"]
@@ -77,7 +79,9 @@ jobs:
         run: CHROMIUM_BIN=$(which chrome) npm run test:browser:chromium
 
   test-browser-firefox:
-    runs-on: ubuntu-latest
+    # Runner image version is temporarily pinned to `ubuntu-22.04`.
+    # TODO: Restore it to `ubuntu-latest` as soon as compatibility issues with `browser-actions/setup-firefox@latest` are sorted out.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         firefox: ["84.0", "latest-beta", "latest"]
@@ -121,7 +125,9 @@ jobs:
         run: npm run test:bun
 
   test-chromium-extension-chrome:
-    runs-on: ubuntu-latest
+    # Runner image version is temporarily pinned to `ubuntu-22.04`.
+    # TODO: Restore it to `ubuntu-latest` as soon as compatibility issues with `browser-actions/setup-chrome@latest` are sorted out.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         chrome: ["beta", "stable"]


### PR DESCRIPTION
### Describe the purpose of your pull request

It seems that the [migration](https://dev.to/siddhantkcode/critical-changes-coming-to-github-actions-ubuntu-24-migration-guide-oo8) of the `ubuntu-latest` runner image from 22.04 to 24.04 breaks the setup of some GitHub Actions checks. E.g. `browser-actions/setup-chrome@latest` and `browser-actions/setup-firefox@latest` seem to have compatibility issues with the latest Ubuntu image.

So, as a temporary workaround, we pin the Ubuntu image version to 22.04 for the problematic checks.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
