### PR TITLE
Re-enable test run for Firefox latest beta

### DIFF
--- a/.github/workflows/js-sdk-ci.yml
+++ b/.github/workflows/js-sdk-ci.yml
@@ -84,9 +84,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        # "latest-beta" is temporary removed until browser-actions/setup-firefox@latest is fixed
-        # (see also https://github.com/browser-actions/setup-firefox/issues/621)
-        firefox: ["84.0", "latest"]
+        firefox: ["84.0", "latest", "latest-beta"]
     name: Browser - Firefox ${{ matrix.firefox }} test
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Describe the purpose of your pull request

Re-enables test run for Firefox latest beta as the issue with `browser-actions/setup-firefox` got solved.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
