### PR TITLE
Allow custom config fetcher + include CF ray ID

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,7 @@ DEPLOY.md
 deno.*
 deno.*.*
 deploy.sh
+eslint.config.mjs
 extra-checks/
 gulpfile.js
 karma.*.conf.js

--- a/extra-checks/ts-compat-check/index.ts
+++ b/extra-checks/ts-compat-check/index.ts
@@ -1,4 +1,3 @@
 import "../../lib/esm/browser";
 import "../../lib/esm/chromium-extension";
-import "../../lib/esm/deno";
 import "../../lib/esm/node";

--- a/extra-checks/ts-compat-check/shims.d.ts
+++ b/extra-checks/ts-compat-check/shims.d.ts
@@ -1,6 +1,6 @@
 declare module "http" {
     export class IncomingMessage { }
-    export class OutgoingHttpHeaders { }
+    export type OutgoingHttpHeader = unknown;
 }
 
 declare module "@cloudflare/workers-types/2023-03-01" {

--- a/extra-checks/ts-compat-check/shims.d.ts
+++ b/extra-checks/ts-compat-check/shims.d.ts
@@ -1,0 +1,14 @@
+declare module "http" {
+    export class IncomingMessage { }
+    export class OutgoingHttpHeaders { }
+}
+
+declare module "@cloudflare/workers-types/2023-03-01" {
+    
+}
+
+declare namespace chrome {
+    export namespace storage {
+        export class LocalStorageArea { }
+    }
+}

--- a/extra-checks/ts-compat-check/shims.d.ts
+++ b/extra-checks/ts-compat-check/shims.d.ts
@@ -4,7 +4,6 @@ declare module "http" {
 }
 
 declare module "@cloudflare/workers-types/2023-03-01" {
-    
 }
 
 declare namespace chrome {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,7 @@ async function postProcess(targetId, targetFile, targetDir, { importExtension, r
       // Fix extensions of referenced files in export/import statements.
       let fileContent = await fsp.readFile(file, "utf8");
       const isEsm = addModulePackageJson || isDts;
-      fileContent = (isEsm ? fixEsmImports : fixCjsImports)(targetDir, fileContent, importExtension);
+      fileContent = (isEsm ? fixEsmImports : fixCjsImports)(path.dirname(file), fileContent, importExtension);
       if (fileContent != null) await fsp.writeFile(file, fileContent, "utf8", { flush: true });
     }
   }

--- a/karma.browser.conf.js
+++ b/karma.browser.conf.js
@@ -4,12 +4,6 @@ module.exports = function(config) {
   config.set({
     frameworks: ["mocha", "chai", "webpack"],
 
-    client: {
-      mocha: {
-        timeout: 30000,
-      },
-    },
-
     files: [
       { pattern: "test/browser/index.ts", watched: false },
       { pattern: "test/data/**", included: false, watched: false, served: true },

--- a/karma.chromium-extension.conf.js
+++ b/karma.chromium-extension.conf.js
@@ -4,12 +4,6 @@ module.exports = function(config) {
   config.set({
     frameworks: ["mocha", "chai", "webpack"],
 
-    client: {
-      mocha: {
-        timeout: 30000,
-      },
-    },
-
     files: [
       { pattern: "test/chromium-extension/index.ts", watched: false },
       { pattern: "test/data/**", included: false, watched: false, served: true },

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -1,5 +1,5 @@
 import type { AutoPollOptions } from "./ConfigCatClientOptions";
-import type { FetchResult, IConfigFetcher } from "./ConfigFetcher";
+import type { FetchResult } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
@@ -17,9 +17,9 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
   private readonly pollExpirationMs: number;
   readonly readyPromise: Promise<ClientCacheState>;
 
-  constructor(configFetcher: IConfigFetcher, options: AutoPollOptions) {
+  constructor(options: AutoPollOptions) {
 
-    super(configFetcher, options);
+    super(options);
 
     this.pollIntervalMs = options.pollIntervalSeconds * 1000;
     // Due to the inaccuracy of the timer, some tolerance should be allowed when checking for

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -1,6 +1,6 @@
 import { AutoPollConfigService } from "./AutoPollConfigService";
 import type { ConfigCatClientOptions, IConfigCatKernel, OptionsBase, OptionsForPollingMode } from "./ConfigCatClientOptions";
-import { AutoPollOptions, LazyLoadOptions, ManualPollOptions, PollingMode } from "./ConfigCatClientOptions";
+import { AutoPollOptions, LazyLoadOptions, ManualPollOptions, PollingMode, PROXY_SDKKEY_PREFIX } from "./ConfigCatClientOptions";
 import type { LoggerWrapper } from "./ConfigCatLogger";
 import type { IConfigService } from "./ConfigServiceBase";
 import { ClientCacheState, RefreshErrorCode, RefreshResult } from "./ConfigServiceBase";
@@ -759,10 +759,8 @@ export type SettingKeyValue<TValue extends SettingValue = SettingValue> = {
 };
 
 function isValidSdkKey(sdkKey: string, customBaseUrl: boolean) {
-  const proxyPrefix = "configcat-proxy/";
-
   // NOTE: String.prototype.startsWith was introduced after ES5. We'd rather work around it instead of polyfilling it.
-  if (customBaseUrl && sdkKey.length > proxyPrefix.length && sdkKey.lastIndexOf(proxyPrefix, 0) === 0) {
+  if (customBaseUrl && sdkKey.length > PROXY_SDKKEY_PREFIX.length && sdkKey.lastIndexOf(PROXY_SDKKEY_PREFIX, 0) === 0) {
     return true;
   }
 

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -258,20 +258,20 @@ export class ConfigCatClient implements IConfigCatClient {
       throw new Error(invalidSdkKeyError);
     }
 
-    const actualOptions =
+    const internalOptions =
       pollingMode === PollingMode.AutoPoll ? new AutoPollOptions(sdkKey, configCatKernel, options)
       : pollingMode === PollingMode.ManualPoll ? new ManualPollOptions(sdkKey, configCatKernel, options)
       : pollingMode === PollingMode.LazyLoad ? new LazyLoadOptions(sdkKey, configCatKernel, options)
       : throwError(new Error("Invalid 'pollingMode' value"));
 
-    if (actualOptions.flagOverrides?.behaviour !== OverrideBehaviour.LocalOnly && !isValidSdkKey(sdkKey, actualOptions.baseUrlOverriden)) {
+    if (internalOptions.flagOverrides?.behaviour !== OverrideBehaviour.LocalOnly && !isValidSdkKey(sdkKey, internalOptions.baseUrlOverriden)) {
       throw new Error(invalidSdkKeyError);
     }
 
-    const [instance, instanceAlreadyCreated] = clientInstanceCache.getOrCreate(actualOptions);
+    const [instance, instanceAlreadyCreated] = clientInstanceCache.getOrCreate(internalOptions);
 
     if (instanceAlreadyCreated && options) {
-      actualOptions.logger.clientIsAlreadyCreated(sdkKey);
+      internalOptions.logger.clientIsAlreadyCreated(sdkKey);
     }
 
     return instance;

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -1,12 +1,9 @@
 import { AutoPollConfigService } from "./AutoPollConfigService";
-import type { IConfigCache } from "./ConfigCatCache";
-import type { ConfigCatClientOptions, OptionsBase, OptionsForPollingMode } from "./ConfigCatClientOptions";
+import type { ConfigCatClientOptions, IConfigCatKernel, OptionsBase, OptionsForPollingMode } from "./ConfigCatClientOptions";
 import { AutoPollOptions, LazyLoadOptions, ManualPollOptions, PollingMode } from "./ConfigCatClientOptions";
 import type { LoggerWrapper } from "./ConfigCatLogger";
-import type { IConfigFetcher } from "./ConfigFetcher";
 import type { IConfigService } from "./ConfigServiceBase";
 import { ClientCacheState, RefreshErrorCode, RefreshResult } from "./ConfigServiceBase";
-import type { IEventEmitter } from "./EventEmitter";
 import { nameOfOverrideBehaviour, OverrideBehaviour } from "./FlagOverrides";
 import type { HookEvents, Hooks, IProvidesHooks } from "./Hooks";
 import { LazyLoadConfigService } from "./LazyLoadConfigService";
@@ -189,18 +186,10 @@ export interface IConfigCatClientSnapshot {
   getValueDetails<T extends SettingValue>(key: string, defaultValue: T, user?: IUser): IEvaluationDetails<SettingTypeOf<T>>;
 }
 
-export interface IConfigCatKernel {
-  configFetcher: IConfigFetcher;
-  sdkType: string;
-  sdkVersion: string;
-  defaultCacheFactory?: (options: OptionsBase) => IConfigCache;
-  eventEmitterFactory?: () => IEventEmitter;
-}
-
 export class ConfigCatClientCache {
   private readonly instances: Record<string, [WeakRef<ConfigCatClient>, object]> = {};
 
-  getOrCreate(options: ConfigCatClientOptions, configCatKernel: IConfigCatKernel): [ConfigCatClient, boolean] {
+  getOrCreate(options: ConfigCatClientOptions): [ConfigCatClient, boolean] {
     let instance: ConfigCatClient | undefined;
 
     const cachedInstance = this.instances[options.sdkKey];
@@ -213,7 +202,7 @@ export class ConfigCatClientCache {
     }
 
     const token = {};
-    instance = new ConfigCatClient(options, configCatKernel, token);
+    instance = new ConfigCatClient(options, token);
     const weakRefCtor = isWeakRefAvailable() ? WeakRef : getWeakRefStub();
     this.instances[options.sdkKey] = [new weakRefCtor(instance), token];
     return [instance, false];
@@ -269,20 +258,17 @@ export class ConfigCatClient implements IConfigCatClient {
       throw new Error(invalidSdkKeyError);
     }
 
-    const optionsClass =
-      pollingMode === PollingMode.AutoPoll ? AutoPollOptions
-      : pollingMode === PollingMode.ManualPoll ? ManualPollOptions
-      : pollingMode === PollingMode.LazyLoad ? LazyLoadOptions
+    const actualOptions =
+      pollingMode === PollingMode.AutoPoll ? new AutoPollOptions(sdkKey, configCatKernel, options)
+      : pollingMode === PollingMode.ManualPoll ? new ManualPollOptions(sdkKey, configCatKernel, options)
+      : pollingMode === PollingMode.LazyLoad ? new LazyLoadOptions(sdkKey, configCatKernel, options)
       : throwError(new Error("Invalid 'pollingMode' value"));
-
-    const actualOptions = new optionsClass(sdkKey, configCatKernel.sdkType, configCatKernel.sdkVersion, options,
-      configCatKernel.defaultCacheFactory, configCatKernel.eventEmitterFactory);
 
     if (actualOptions.flagOverrides?.behaviour !== OverrideBehaviour.LocalOnly && !isValidSdkKey(sdkKey, actualOptions.baseUrlOverriden)) {
       throw new Error(invalidSdkKeyError);
     }
 
-    const [instance, instanceAlreadyCreated] = clientInstanceCache.getOrCreate(actualOptions, configCatKernel);
+    const [instance, instanceAlreadyCreated] = clientInstanceCache.getOrCreate(actualOptions);
 
     if (instanceAlreadyCreated && options) {
       actualOptions.logger.clientIsAlreadyCreated(sdkKey);
@@ -293,7 +279,6 @@ export class ConfigCatClient implements IConfigCatClient {
 
   constructor(
     options: ConfigCatClientOptions,
-    configCatKernel: IConfigCatKernel,
     private readonly cacheToken?: object) {
 
     if (!options) {
@@ -303,14 +288,6 @@ export class ConfigCatClient implements IConfigCatClient {
     this.options = options;
 
     this.options.logger.debug("Initializing ConfigCatClient. Options: " + JSON.stringify(this.options));
-
-    if (!configCatKernel) {
-      throw new Error("Invalid 'configCatKernel' value");
-    }
-
-    if (!configCatKernel.configFetcher) {
-      throw new Error("Invalid 'configCatKernel.configFetcher' value");
-    }
 
     // To avoid possible memory leaks, the components of the client should not hold a strong reference to the hooks object (see also SafeHooksWrapper).
     this.hooks = options.yieldHooks();
@@ -323,9 +300,9 @@ export class ConfigCatClient implements IConfigCatClient {
 
     if (options.flagOverrides?.behaviour !== OverrideBehaviour.LocalOnly) {
       this.configService =
-        options instanceof AutoPollOptions ? new AutoPollConfigService(configCatKernel.configFetcher, options)
-        : options instanceof ManualPollOptions ? new ManualPollConfigService(configCatKernel.configFetcher, options)
-        : options instanceof LazyLoadOptions ? new LazyLoadConfigService(configCatKernel.configFetcher, options)
+        options instanceof AutoPollOptions ? new AutoPollConfigService(options)
+        : options instanceof ManualPollOptions ? new ManualPollConfigService(options)
+        : options instanceof LazyLoadOptions ? new LazyLoadConfigService(options)
         : throwError(new Error("Invalid 'options' value"));
     } else {
       this.hooks.emit("clientReady", ClientCacheState.HasLocalOverrideFlagDataOnly);

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -83,6 +83,15 @@ export interface IOptions {
    *
    * If not set, a default implementation will be used depending on the current platform.
    * If you want to use custom a config fetcher, you can provide an implementation of `IConfigCatConfigFetcher`.
+   *
+   * @remarks Implementing a config fetcher that makes HTTP requests to the ConfigCat CDN is tricky, especially when the
+   * SDK runs in a browser. Therefore, please **avoid writing actual config fetcher implementations from scratch**
+   * unless absolutely necessary and you know exactly what you are doing. (Writing mock implementations for testing
+   * purposes is fine, of course.)
+   *
+   * If you use the SDK with a [proxy](https://configcat.com/docs/advanced/proxy/proxy-overview/) and need to set
+   * custom HTTP request headers, you can subclass the built-in config fetcher implementations (e.g. FetchApiConfigFetcher)
+   * and override the `setRequestHeaders` method.
    */
   configFetcher?: IConfigCatConfigFetcher | null;
 

--- a/src/ConfigCatLogger.ts
+++ b/src/ConfigCatLogger.ts
@@ -200,19 +200,27 @@ export class LoggerWrapper implements IConfigCatLogger {
     );
   }
 
-  fetchFailedDueToInvalidSdkKey(): LogMessage {
+  fetchFailedDueToInvalidSdkKey(rayId: string | undefined): LogMessage {
     return this.log(
       LogLevel.Error, 1100,
-      "Your SDK Key seems to be wrong. You can find the valid SDK Key at https://app.configcat.com/sdkkey"
+      rayId == null
+        ? "Your SDK Key seems to be wrong. You can find the valid SDK Key at https://app.configcat.com/sdkkey"
+        : FormattableLogMessage.from(
+          "RAY_ID"
+        )`Your SDK Key seems to be wrong. You can find the valid SDK Key at https://app.configcat.com/sdkkey (Ray ID: ${rayId})`
     );
   }
 
-  fetchFailedDueToUnexpectedHttpResponse(statusCode: number, reasonPhrase: string): LogMessage {
+  fetchFailedDueToUnexpectedHttpResponse(statusCode: number, reasonPhrase: string, rayId: string | undefined): LogMessage {
     return this.log(
       LogLevel.Error, 1101,
-      FormattableLogMessage.from(
-        "STATUS_CODE", "REASON_PHRASE"
-      )`Unexpected HTTP response was received while trying to fetch config JSON: ${statusCode} ${reasonPhrase}`
+      rayId == null
+        ? FormattableLogMessage.from(
+          "STATUS_CODE", "REASON_PHRASE"
+        )`Unexpected HTTP response was received while trying to fetch config JSON: ${statusCode} ${reasonPhrase}`
+        : FormattableLogMessage.from(
+          "STATUS_CODE", "REASON_PHRASE", "RAY_ID"
+        )`Unexpected HTTP response was received while trying to fetch config JSON: ${statusCode} ${reasonPhrase} (Ray ID: ${rayId})`
     );
   }
 
@@ -233,27 +241,39 @@ export class LoggerWrapper implements IConfigCatLogger {
     );
   }
 
-  fetchFailedDueToRedirectLoop(): LogMessage {
+  fetchFailedDueToRedirectLoop(rayId: string | undefined): LogMessage {
     return this.log(
       LogLevel.Error, 1104,
-      "Redirection loop encountered while trying to fetch config JSON. Please contact us at https://configcat.com/support/"
+      rayId == null
+        ? "Redirection loop encountered while trying to fetch config JSON. Please contact us at https://configcat.com/support/"
+        : FormattableLogMessage.from(
+          "RAY_ID"
+        )`Redirection loop encountered while trying to fetch config JSON. Please contact us at https://configcat.com/support/ (Ray ID: ${rayId})`
     );
   }
 
-  fetchReceived200WithInvalidBody(ex: any): LogMessage {
+  fetchReceived200WithInvalidBody(rayId: string | undefined, ex: any): LogMessage {
     return this.log(
       LogLevel.Error, 1105,
-      "Fetching config JSON was successful but the HTTP response content was invalid.",
+      rayId == null
+        ? "Fetching config JSON was successful but the HTTP response content was invalid."
+        : FormattableLogMessage.from(
+          "RAY_ID"
+        )`Fetching config JSON was successful but the HTTP response content was invalid. (Ray ID: ${rayId})`,
       ex
     );
   }
 
-  fetchReceived304WhenLocalCacheIsEmpty(statusCode: number, reasonPhrase: string): LogMessage {
+  fetchReceived304WhenLocalCacheIsEmpty(statusCode: number, reasonPhrase: string, rayId: string | undefined): LogMessage {
     return this.log(
       LogLevel.Error, 1106,
-      FormattableLogMessage.from(
-        "STATUS_CODE", "REASON_PHRASE"
-      )`Unexpected HTTP response was received when no config JSON is cached locally: ${statusCode} ${reasonPhrase}`
+      rayId == null
+        ? FormattableLogMessage.from(
+          "STATUS_CODE", "REASON_PHRASE"
+        )`Unexpected HTTP response was received when no config JSON is cached locally: ${statusCode} ${reasonPhrase}`
+        : FormattableLogMessage.from(
+          "STATUS_CODE", "REASON_PHRASE", "RAY_ID"
+        )`Unexpected HTTP response was received when no config JSON is cached locally: ${statusCode} ${reasonPhrase} (Ray ID: ${rayId})`
     );
   }
 

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -56,7 +56,7 @@ export class FetchResponse {
   /** The value of the `ETag` HTTP response header. */
   readonly eTag?: string;
 
-  protected readonly rayId?: string;
+  private readonly rayId?: string;
 
   constructor(
     /** The HTTP status code. */

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -121,7 +121,7 @@ export interface IConfigCatConfigFetcher {
   /**
    * Fetches the JSON content of the requested config asynchronously.
    * @param request The fetch request.
-   * @returns A promise that fulfills the fetch response.
+   * @returns A promise that fulfills with the fetch response.
    * @throws {FetchErrorException} The fetch operation failed.
    */
   fetchAsync(request: FetchRequest): Promise<FetchResponse>;

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -1,4 +1,3 @@
-import type { OptionsBase } from "./ConfigCatClientOptions";
 import { RefreshErrorCode } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
 import type { Message } from "./Utils";
@@ -32,11 +31,56 @@ export class FetchResult {
   }
 }
 
-export interface IFetchResponse {
-  statusCode: number;
-  reasonPhrase: string;
-  eTag?: string;
-  body?: string;
+/** The request parameters for a ConfigCat config fetch operation. */
+export class FetchRequest {
+  constructor(
+    /** The URL of the config. */
+    readonly url: string,
+    /**
+     * The value of the `ETag` HTTP response header received during the last successful request (if any).
+     * If available, should be included in the HTTP request, either in the `If-None-Match` header or in the `ccetag` query string parameter.
+     *
+     * @remarks In browser runtime environments the `If-None-Match` header should be avoided because that may cause unnecessary CORS preflight requests.
+     */
+    readonly lastETag: string | undefined,
+    /** Additional HTTP request headers. Should be included in every HTTP request. */
+    readonly headers: ReadonlyArray<[name: string, value: string]>,
+    /** The request timeout to apply, configured via `IOptions.requestTimeoutMs`. */
+    readonly timeoutMs: number
+  ) {
+  }
+}
+
+/** The response data of a ConfigCat config fetch operation. */
+export class FetchResponse {
+  /** The value of the `ETag` HTTP response header. */
+  readonly eTag?: string;
+
+  protected readonly rayId?: string;
+
+  constructor(
+    /** The HTTP status code. */
+    readonly statusCode: number,
+    /** The HTTP reason phrase. */
+    readonly reasonPhrase: string,
+    /** The HTTP response headers. */
+    headers: ReadonlyArray<[name: string, value: string]>,
+    /** The response body. */
+    readonly body?: string
+  ) {
+    let eTag: string | undefined, rayId: string | undefined;
+
+    for (const [name, value] of headers) {
+      const normalizedName = name.toLowerCase();
+      if (eTag == null && normalizedName === "etag") {
+        this.eTag = eTag = value;
+        if (rayId != null) break;
+      } else if (rayId == null && normalizedName === "cf-ray") {
+        this.rayId = rayId = value;
+        if (eTag != null) break;
+      }
+    }
+  }
 }
 
 export type FetchErrorCauses = {
@@ -72,6 +116,13 @@ export class FetchError<TCause extends keyof FetchErrorCauses = keyof FetchError
   }
 }
 
-export interface IConfigFetcher {
-  fetchLogic(options: OptionsBase, lastEtag: string | null): Promise<IFetchResponse>;
+/** Defines the interface used by the ConfigCat SDK to perform ConfigCat config fetch operations. */
+export interface IConfigCatConfigFetcher {
+  /**
+   * Fetches the JSON content of the requested config asynchronously.
+   * @param request The fetch request.
+   * @returns A promise that fulfills the fetch response.
+   * @throws {FetchErrorException} The fetch operation failed.
+   */
+  fetchAsync(request: FetchRequest): Promise<FetchResponse>;
 }

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -140,8 +140,10 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
     this.configFetcher = options.configFetcher;
     this.requestUrl = options.getUrl();
-    // TODO: send user agent header?
-    this.requestHeaders = [];
+    this.requestHeaders = [
+      ["User-Agent", options.clientVersion],
+      ["X-ConfigCat-UserAgent", options.clientVersion],
+    ];
 
     this.status = options.offline ? ConfigServiceStatus.Offline : ConfigServiceStatus.Online;
   }

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -128,7 +128,6 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
   protected readonly cacheKey: string;
 
   protected readonly configFetcher: IConfigCatConfigFetcher;
-  private requestUrl: string;
   private readonly requestHeaders: ReadonlyArray<[string, string]>;
 
   abstract readonly readyPromise: Promise<ClientCacheState>;
@@ -139,7 +138,6 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     this.cacheKey = options.getCacheKey();
 
     this.configFetcher = options.configFetcher;
-    this.requestUrl = options.getUrl();
     this.requestHeaders = [
       ["User-Agent", options.clientVersion],
       ["X-ConfigCat-UserAgent", options.clientVersion],
@@ -287,7 +285,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     for (let retryNumber = 0; ; retryNumber++) {
       options.logger.debug(`ConfigServiceBase.fetchRequestAsync(): calling fetchLogic()${retryNumber > 0 ? `, retry ${retryNumber}/${maxRetryCount}` : ""}`);
 
-      const request = new FetchRequest(this.requestUrl, lastETag, this.requestHeaders, options.requestTimeoutMs);
+      const request = new FetchRequest(options.getUrl(), lastETag, this.requestHeaders, options.requestTimeoutMs);
       const response = await this.configFetcher.fetchAsync(request);
 
       if (response.statusCode !== 200) {
@@ -331,7 +329,6 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       }
 
       options.baseUrl = baseUrl;
-      this.requestUrl = options.getUrl();
 
       if (redirect === RedirectMode.No) {
         return [response, config];

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -3,8 +3,8 @@ import { ExternalConfigCache, InMemoryConfigCache } from "./ConfigCatCache";
 import type { OptionsBase } from "./ConfigCatClientOptions";
 import type { LogMessage } from "./ConfigCatLogger";
 import { toMessage } from "./ConfigCatLogger";
-import type { FetchErrorCauses, IConfigFetcher, IFetchResponse } from "./ConfigFetcher";
-import { FetchError, FetchResult, FetchStatus } from "./ConfigFetcher";
+import type { FetchErrorCauses, FetchResponse, IConfigCatConfigFetcher } from "./ConfigFetcher";
+import { FetchError, FetchRequest, FetchResult, FetchStatus } from "./ConfigFetcher";
 import { RedirectMode } from "./ConfigJson";
 import { Config, ProjectConfig } from "./ProjectConfig";
 import type { Message } from "./Utils";
@@ -127,16 +127,22 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
   protected readonly cacheKey: string;
 
+  protected readonly configFetcher: IConfigCatConfigFetcher;
+  private requestUrl: string;
+  private readonly requestHeaders: ReadonlyArray<[string, string]>;
+
   abstract readonly readyPromise: Promise<ClientCacheState>;
 
   constructor(
-    protected readonly configFetcher: IConfigFetcher,
     protected readonly options: TOptions) {
 
     this.cacheKey = options.getCacheKey();
 
-    this.configFetcher = configFetcher;
-    this.options = options;
+    this.configFetcher = options.configFetcher;
+    this.requestUrl = options.getUrl();
+    // TODO: send user agent header?
+    this.requestHeaders = [];
+
     this.status = options.offline ? ConfigServiceStatus.Offline : ConfigServiceStatus.Online;
   }
 
@@ -226,7 +232,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     let errorMessage: LogMessage;
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const [response, configOrError] = await this.fetchRequestAsync(lastConfig.httpETag ?? null);
+      const [response, configOrError] = await this.fetchRequestAsync(lastConfig.httpETag);
 
       switch (response.statusCode) {
         case 200: // OK
@@ -272,13 +278,15 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-  private async fetchRequestAsync(lastETag: string | null, maxRetryCount = 2): Promise<[IFetchResponse, (Config | any)?]> {
+  private async fetchRequestAsync(lastETag: string | undefined, maxRetryCount = 2): Promise<[FetchResponse, (Config | any)?]> {
     const options = this.options;
     options.logger.debug("ConfigServiceBase.fetchRequestAsync() called.");
 
     for (let retryNumber = 0; ; retryNumber++) {
       options.logger.debug(`ConfigServiceBase.fetchRequestAsync(): calling fetchLogic()${retryNumber > 0 ? `, retry ${retryNumber}/${maxRetryCount}` : ""}`);
-      const response = await this.configFetcher.fetchLogic(options, lastETag);
+
+      const request = new FetchRequest(this.requestUrl, lastETag, this.requestHeaders, options.requestTimeoutMs);
+      const response = await this.configFetcher.fetchAsync(request);
 
       if (response.statusCode !== 200) {
         return [response];
@@ -321,6 +329,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       }
 
       options.baseUrl = baseUrl;
+      this.requestUrl = options.getUrl();
 
       if (redirect === RedirectMode.No) {
         return [response, config];

--- a/src/LazyLoadConfigService.ts
+++ b/src/LazyLoadConfigService.ts
@@ -1,6 +1,5 @@
 import type { LazyLoadOptions } from "./ConfigCatClientOptions";
 import type { LoggerWrapper } from "./ConfigCatLogger";
-import type { IConfigFetcher } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
@@ -10,9 +9,9 @@ export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> im
   private readonly cacheTimeToLiveMs: number;
   readonly readyPromise: Promise<ClientCacheState>;
 
-  constructor(configFetcher: IConfigFetcher, options: LazyLoadOptions) {
+  constructor(options: LazyLoadOptions) {
 
-    super(configFetcher, options);
+    super(options);
 
     this.cacheTimeToLiveMs = options.cacheTimeToLiveSeconds * 1000;
 

--- a/src/ManualPollConfigService.ts
+++ b/src/ManualPollConfigService.ts
@@ -1,5 +1,4 @@
 import type { ManualPollOptions } from "./ConfigCatClientOptions";
-import type { IConfigFetcher } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
@@ -8,9 +7,9 @@ export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions
 
   readonly readyPromise: Promise<ClientCacheState>;
 
-  constructor(configFetcher: IConfigFetcher, options: ManualPollOptions) {
+  constructor(options: ManualPollOptions) {
 
-    super(configFetcher, options);
+    super(options);
 
     const initialCacheSyncUp = this.syncUpWithCache();
     this.readyPromise = this.getReadyPromise(initialCacheSyncUp);

--- a/src/browser/LocalStorageConfigCache.ts
+++ b/src/browser/LocalStorageConfigCache.ts
@@ -3,7 +3,7 @@ import { ExternalConfigCache } from "../ConfigCatCache";
 import type { OptionsBase } from "../ConfigCatClientOptions";
 
 export class LocalStorageConfigCache implements IConfigCatCache {
-  static tryGetFactory(): ((options: OptionsBase) => IConfigCache) | undefined {
+  private static tryGetFactory(): ((options: OptionsBase) => IConfigCache) | undefined {
     const localStorage = getLocalStorage();
     if (localStorage) {
       return options => new ExternalConfigCache(new LocalStorageConfigCache(localStorage), options.logger);

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -4,7 +4,7 @@ import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { FetchError, FetchResponse } from "../ConfigFetcher";
 
 export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
-  static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
+  private static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
     return options => {
       const configFetcher = new XmlHttpRequestConfigFetcher();
       configFetcher.logger = options.logger;
@@ -67,13 +67,13 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     });
   }
 
-  private setRequestHeaders(httpRequest: XMLHttpRequest, headers: ReadonlyArray<[string, string]>) {
+  protected setRequestHeaders(httpRequest: XMLHttpRequest, headers: ReadonlyArray<[string, string]>): void {
     for (const [name, value] of headers) {
       httpRequest.setRequestHeader(name, value);
     }
   }
 
-  private getResponseHeaders(httpRequest: XMLHttpRequest): [string, string][] {
+  protected getResponseHeaders(httpRequest: XMLHttpRequest): [string, string][] {
     const headers: [string, string][] = [];
     extractHeader("ETag", httpRequest, headers);
     extractHeader("CF-RAY", httpRequest, headers);

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -1,20 +1,30 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
-import type { IConfigFetcher, IFetchResponse } from "../ConfigFetcher";
-import { FetchError } from "../ConfigFetcher";
+import type { LoggerWrapper } from "../ConfigCatLogger";
+import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import { FetchError, FetchResponse } from "../ConfigFetcher";
 
-export class XmlHttpRequestConfigFetcher implements IConfigFetcher {
-  private handleStateChange(httpRequest: XMLHttpRequest, resolve: (value: IFetchResponse) => void, reject: (reason?: any) => void) {
+export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
+  static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
+    return options => {
+      const configFetcher = new XmlHttpRequestConfigFetcher();
+      configFetcher.logger = options.logger;
+      return configFetcher;
+    };
+  }
+
+  private logger?: LoggerWrapper;
+
+  private handleStateChange(httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
     try {
       if (httpRequest.readyState === 4) {
         const { status: statusCode, statusText: reasonPhrase } = httpRequest;
 
-        if (statusCode === 200) {
-          const eTag: string | undefined = httpRequest.getResponseHeader("ETag") ?? void 0;
-          resolve({ statusCode, reasonPhrase, eTag, body: httpRequest.responseText });
-        } else if (statusCode) {
-          // The readystatechange event is emitted even in the case of abort or error.
-          // We can detect this by checking for zero status code (see https://stackoverflow.com/a/19247992/8656352).
-          resolve({ statusCode, reasonPhrase });
+        // The readystatechange event is emitted even in the case of abort or error.
+        // We can detect this by checking for zero status code (see https://stackoverflow.com/a/19247992/8656352).
+        if (statusCode) {
+          const headers = this.getResponseHeaders(httpRequest);
+          const body = statusCode === 200 ? httpRequest.responseText : void 0;
+          resolve(new FetchResponse(statusCode, reasonPhrase, headers, body));
         }
       }
     } catch (err) {
@@ -22,34 +32,58 @@ export class XmlHttpRequestConfigFetcher implements IConfigFetcher {
     }
   }
 
-  fetchLogic(options: OptionsBase, lastEtag: string | null): Promise<IFetchResponse> {
-    return new Promise<IFetchResponse>((resolve, reject) => {
+  fetchAsync(request: FetchRequest): Promise<FetchResponse> {
+    return new Promise<FetchResponse>((resolve, reject) => {
       try {
-        options.logger.debug("HttpConfigFetcher.fetchLogic() called.");
+        this.logger?.debug("XmlHttpRequestConfigFetcher.fetchAsync() called.");
+
+        let { url } = request;
+        const { lastETag, timeoutMs } = request;
+
+        if (lastETag) {
+          // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header,
+          // we can transform this query param to the header in our CDN provider.
+          url += "&ccetag=" + encodeURIComponent(lastETag);
+        }
 
         const httpRequest: XMLHttpRequest = new XMLHttpRequest();
 
         httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject);
-        httpRequest.ontimeout = () => reject(new FetchError("timeout", options.requestTimeoutMs));
+        httpRequest.ontimeout = () => reject(new FetchError("timeout", timeoutMs));
         httpRequest.onabort = () => reject(new FetchError("abort"));
         httpRequest.onerror = () => reject(new FetchError("failure"));
 
-        let url = options.getUrl();
-        if (lastEtag) {
-          // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header,
-          // we can transorm this query param to the header in our CDN provider.
-          url += "&ccetag=" + encodeURIComponent(lastEtag);
-        }
         httpRequest.open("GET", url, true);
-        httpRequest.timeout = options.requestTimeoutMs;
+        httpRequest.timeout = timeoutMs;
         // NOTE: It's intentional that we don't specify the If-None-Match header.
         // The browser automatically handles it, adding it manually would cause an unnecessary CORS OPTIONS request.
         // In case the browser doesn't handle it, we are transforming the ccetag query parameter to the If-None-Match header in our CDN provider.
+        this.setRequestHeaders(httpRequest, request.headers);
         httpRequest.send(null);
       } catch (err) {
         // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
         reject(err);
       }
     });
+  }
+
+  private setRequestHeaders(httpRequest: XMLHttpRequest, headers: ReadonlyArray<[string, string]>) {
+    for (const [name, value] of headers) {
+      httpRequest.setRequestHeader(name, value);
+    }
+  }
+
+  private getResponseHeaders(httpRequest: XMLHttpRequest): [string, string][] {
+    const headers: [string, string][] = [];
+    extractHeader("ETag", httpRequest, headers);
+    extractHeader("CF-RAY", httpRequest, headers);
+    return headers;
+
+    function extractHeader(name: string, httpRequest: XMLHttpRequest, headers: [string, string][]) {
+      const value = httpRequest.getResponseHeader(name);
+      if (value != null) {
+        headers.push([name, value]);
+      }
+    }
   }
 }

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -15,7 +15,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 
   private logger?: LoggerWrapper;
 
-  private handleStateChange(httpRequest: XMLHttpRequest, isCustomUrl: boolean, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
+  private handleStateChange(httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
     try {
       if (httpRequest.readyState === 4) {
         const { status: statusCode, statusText: reasonPhrase } = httpRequest;
@@ -23,7 +23,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
         // The readystatechange event is emitted even in the case of abort or error.
         // We can detect this by checking for zero status code (see https://stackoverflow.com/a/19247992/8656352).
         if (statusCode) {
-          const headers = isCustomUrl ? this.getResponseHeaders(httpRequest) : getResponseHeadersDefault(httpRequest);
+          const headers = getResponseHeadersDefault(httpRequest);
           const body = statusCode === 200 ? httpRequest.responseText : void 0;
           resolve(new FetchResponse(statusCode, reasonPhrase, headers, body));
         }
@@ -51,7 +51,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 
         const httpRequest: XMLHttpRequest = new XMLHttpRequest();
 
-        httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, isCustomUrl, resolve, reject);
+        httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject);
         httpRequest.ontimeout = () => reject(new FetchError("timeout", timeoutMs));
         httpRequest.onabort = () => reject(new FetchError("abort"));
         httpRequest.onerror = () => reject(new FetchError("failure"));
@@ -70,10 +70,6 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   }
 
   protected setRequestHeaders(httpRequest: XMLHttpRequest, headers: ReadonlyArray<[string, string]>): void {
-  }
-
-  protected getResponseHeaders(httpRequest: XMLHttpRequest): [string, string][] {
-    return getResponseHeadersDefault(httpRequest);
   }
 }
 

--- a/src/browser/index.root.ts
+++ b/src/browser/index.root.ts
@@ -1,4 +1,41 @@
+import type { IConfigCatClient } from "../ConfigCatClient";
+import type { OptionsForPollingMode, PollingMode } from "../ConfigCatClientOptions";
+import { getClient as getClientImpl } from ".";
+
 /* Package public API for browsers or separate packages that implement a ConfigCat SDK. */
 
+/**
+ * Returns an instance of `ConfigCatClient` for the specified SDK Key.
+ * @remarks This method returns a single, shared instance per each distinct SDK Key.
+ * That is, a new client object is created only when there is none available for the specified SDK Key.
+ * Otherwise, the already created instance is returned (in which case the `pollingMode` and `options` arguments are ignored).
+ * So, please keep in mind that when you make multiple calls to this method using the same SDK Key, you may end up with multiple references to the same client object.
+ * @param sdkKey SDK Key to access the ConfigCat config.
+ * @param pollingMode The polling mode to use.
+ * @param options Options for the specified polling mode.
+ */
+export const getClient: <TMode extends PollingMode | undefined>(
+  sdkKey: string, pollingMode?: TMode, options?: OptionsForPollingMode<TMode>
+) => IConfigCatClient = getClientImpl;
+
+export { createConsoleLogger, createFlagOverridesFromMap, disposeAllClients } from "../index.pubternals.core";
+
+export type { INodeAutoPollOptions, INodeLazyLoadingOptions, INodeManualPollOptions } from "../node";
+
+export type { IJSAutoPollOptions, IJSLazyLoadingOptions, IJSManualPollOptions } from ".";
+
+export type { OptionsForPollingMode };
+
+export { LocalStorageConfigCache } from "./LocalStorageConfigCache";
+
+export { IndexedDBConfigCache } from "../shared/IndexedDBConfigCache";
+
+export { XmlHttpRequestConfigFetcher } from "./XmlHttpRequestConfigFetcher";
+
+export { FetchApiConfigFetcher } from "../shared/FetchApiConfigFetcher";
+
+export type { NodeHttpConfigFetcher } from "../node/NodeHttpConfigFetcher";
+
 export * as Internals from "../index.pubternals";
-export * from ".";
+
+export * from "..";

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -31,9 +31,9 @@ export function getClient<TMode extends PollingMode | undefined>(sdkKey: string,
     defaultCacheFactory: typeof localStorage !== "undefined"
       // NOTE: The IndexedDB API is asynchronous, so it's not possible to check here if it actually works. For this reason,
       // we'd rather not fall back to IndexedDB if LocalStorage doesn't work. (In that case, IndexedDB is unlikely to work anyway.)
-      ? LocalStorageConfigCache.tryGetFactory()
-      : IndexedDBConfigCache.tryGetFactory(),
-    configFetcherFactory: XmlHttpRequestConfigFetcher.getFactory(),
+      ? LocalStorageConfigCache["tryGetFactory"]()
+      : IndexedDBConfigCache["tryGetFactory"](),
+    configFetcherFactory: XmlHttpRequestConfigFetcher["getFactory"](),
   });
 }
 
@@ -59,5 +59,13 @@ export type OptionsForPollingMode<TMode extends PollingMode | undefined> =
     TMode extends PollingMode.LazyLoad ? IJSLazyLoadingOptions :
     TMode extends undefined ? IJSAutoPollOptions :
     never;
+
+export { LocalStorageConfigCache };
+
+export { IndexedDBConfigCache };
+
+export { XmlHttpRequestConfigFetcher };
+
+export { FetchApiConfigFetcher } from "../shared/FetchApiConfigFetcher";
 
 export * from "..";

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -2,7 +2,7 @@ import type { IConfigCatClient } from "../ConfigCatClient";
 import type { IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions } from "../ConfigCatClientOptions";
 import { PollingMode } from "../ConfigCatClientOptions";
 import { DefaultEventEmitter } from "../DefaultEventEmitter";
-import { getClient as getClientCommon } from "../index.pubternals.core";
+import { getClient as getClientInternal } from "../index.pubternals.core";
 import { setupPolyfills } from "../Polyfills";
 import { IndexedDBConfigCache } from "../shared/IndexedDBConfigCache";
 import CONFIGCAT_SDK_VERSION from "../Version";
@@ -24,8 +24,7 @@ setupPolyfills();
  * @param options Options for the specified polling mode.
  */
 export function getClient<TMode extends PollingMode | undefined>(sdkKey: string, pollingMode?: TMode, options?: OptionsForPollingMode<TMode>): IConfigCatClient {
-  return getClientCommon(sdkKey, pollingMode ?? PollingMode.AutoPoll, options, {
-    configFetcher: new XmlHttpRequestConfigFetcher(),
+  return getClientInternal(sdkKey, pollingMode ?? PollingMode.AutoPoll, options, {
     sdkType: "ConfigCat-UnifiedJS-Browser",
     sdkVersion: CONFIGCAT_SDK_VERSION,
     eventEmitterFactory: () => new DefaultEventEmitter(),
@@ -34,6 +33,7 @@ export function getClient<TMode extends PollingMode | undefined>(sdkKey: string,
       // we'd rather not fall back to IndexedDB if LocalStorage doesn't work. (In that case, IndexedDB is unlikely to work anyway.)
       ? LocalStorageConfigCache.tryGetFactory()
       : IndexedDBConfigCache.tryGetFactory(),
+    configFetcherFactory: XmlHttpRequestConfigFetcher.getFactory(),
   });
 }
 

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "events";
 import type { IConfigCatClient } from "../ConfigCatClient";
 import type { IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions } from "../ConfigCatClientOptions";
 import { PollingMode } from "../ConfigCatClientOptions";
-import { getClient as getClientCommon } from "../index.pubternals.core";
+import { getClient as getClientInternal } from "../index.pubternals.core";
 import { NodeHttpConfigFetcher } from "../node/NodeHttpConfigFetcher";
 import CONFIGCAT_SDK_VERSION from "../Version";
 
@@ -19,12 +19,12 @@ import CONFIGCAT_SDK_VERSION from "../Version";
  * @param options Options for the specified polling mode.
  */
 export function getClient<TMode extends PollingMode | undefined>(sdkKey: string, pollingMode?: TMode, options?: OptionsForPollingMode<TMode>): IConfigCatClient {
-  return getClientCommon(sdkKey, pollingMode ?? PollingMode.AutoPoll, options,
+  return getClientInternal(sdkKey, pollingMode ?? PollingMode.AutoPoll, options,
     {
-      configFetcher: new NodeHttpConfigFetcher(),
       sdkType: "ConfigCat-UnifiedJS-Bun",
       sdkVersion: CONFIGCAT_SDK_VERSION,
       eventEmitterFactory: () => new EventEmitter(),
+      configFetcherFactory: NodeHttpConfigFetcher.getFactory(),
     });
 }
 

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -24,7 +24,7 @@ export function getClient<TMode extends PollingMode | undefined>(sdkKey: string,
       sdkType: "ConfigCat-UnifiedJS-Bun",
       sdkVersion: CONFIGCAT_SDK_VERSION,
       eventEmitterFactory: () => new EventEmitter(),
-      configFetcherFactory: NodeHttpConfigFetcher.getFactory(),
+      configFetcherFactory: NodeHttpConfigFetcher["getFactory"](),
     });
 }
 
@@ -48,5 +48,9 @@ export type OptionsForPollingMode<TMode extends PollingMode | undefined> =
   TMode extends PollingMode.LazyLoad ? IBunLazyLoadingOptions :
   TMode extends undefined ? IBunAutoPollOptions :
   never;
+
+export { NodeHttpConfigFetcher };
+
+export { FetchApiConfigFetcher } from "../shared/FetchApiConfigFetcher";
 
 export * from "..";

--- a/src/chromium-extension/ChromeLocalStorageConfigCache.ts
+++ b/src/chromium-extension/ChromeLocalStorageConfigCache.ts
@@ -5,7 +5,7 @@ import type { OptionsBase } from "../ConfigCatClientOptions";
 /* eslint-disable @typescript-eslint/no-deprecated */
 
 export class ChromeLocalStorageConfigCache implements IConfigCatCache {
-  static tryGetFactory(): ((options: OptionsBase) => IConfigCache) | undefined {
+  private static tryGetFactory(): ((options: OptionsBase) => IConfigCache) | undefined {
     const localStorage = getChromeLocalStorage();
     if (localStorage) {
       return options => new ExternalConfigCache(new ChromeLocalStorageConfigCache(localStorage), options.logger);

--- a/src/chromium-extension/index.ts
+++ b/src/chromium-extension/index.ts
@@ -28,8 +28,8 @@ export function getClient<TMode extends PollingMode | undefined>(sdkKey: string,
     sdkType: "ConfigCat-UnifiedJS-ChromiumExtension",
     sdkVersion: CONFIGCAT_SDK_VERSION,
     eventEmitterFactory: () => new DefaultEventEmitter(),
-    defaultCacheFactory: ChromeLocalStorageConfigCache.tryGetFactory() ?? IndexedDBConfigCache.tryGetFactory(),
-    configFetcherFactory: FetchApiConfigFetcher.getFactory(),
+    defaultCacheFactory: ChromeLocalStorageConfigCache["tryGetFactory"]() ?? IndexedDBConfigCache["tryGetFactory"](),
+    configFetcherFactory: FetchApiConfigFetcher["getFactory"](),
   });
 }
 
@@ -55,5 +55,11 @@ export type OptionsForPollingMode<TMode extends PollingMode | undefined> =
     TMode extends PollingMode.LazyLoad ? IJSLazyLoadingOptions :
     TMode extends undefined ? IJSAutoPollOptions :
     never;
+
+export { ChromeLocalStorageConfigCache };
+
+export { IndexedDBConfigCache };
+
+export { FetchApiConfigFetcher };
 
 export * from "..";

--- a/src/chromium-extension/index.ts
+++ b/src/chromium-extension/index.ts
@@ -2,7 +2,7 @@ import type { IConfigCatClient } from "../ConfigCatClient";
 import type { IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions } from "../ConfigCatClientOptions";
 import { PollingMode } from "../ConfigCatClientOptions";
 import { DefaultEventEmitter } from "../DefaultEventEmitter";
-import { getClient as getClientCommon } from "../index.pubternals.core";
+import { getClient as getClientInternal } from "../index.pubternals.core";
 import { setupPolyfills } from "../Polyfills";
 import { FetchApiConfigFetcher } from "../shared/FetchApiConfigFetcher";
 import { IndexedDBConfigCache } from "../shared/IndexedDBConfigCache";
@@ -24,12 +24,12 @@ setupPolyfills();
  * @param options Options for the specified polling mode.
  */
 export function getClient<TMode extends PollingMode | undefined>(sdkKey: string, pollingMode?: TMode, options?: OptionsForPollingMode<TMode>): IConfigCatClient {
-  return getClientCommon(sdkKey, pollingMode ?? PollingMode.AutoPoll, options, {
-    configFetcher: new FetchApiConfigFetcher(),
+  return getClientInternal(sdkKey, pollingMode ?? PollingMode.AutoPoll, options, {
     sdkType: "ConfigCat-UnifiedJS-ChromiumExtension",
     sdkVersion: CONFIGCAT_SDK_VERSION,
     eventEmitterFactory: () => new DefaultEventEmitter(),
     defaultCacheFactory: ChromeLocalStorageConfigCache.tryGetFactory() ?? IndexedDBConfigCache.tryGetFactory(),
+    configFetcherFactory: FetchApiConfigFetcher.getFactory(),
   });
 }
 

--- a/src/cloudflare-worker/CloudflareConfigCache.ts
+++ b/src/cloudflare-worker/CloudflareConfigCache.ts
@@ -11,7 +11,7 @@ declare const caches: typeof cloudflare.caches;
 declare const Response: typeof cloudflare.Response;
 
 export class CloudflareConfigCache implements IConfigCatCache {
-  static tryGetFactory(): ((options: OptionsBase) => IConfigCache) | undefined {
+  private static tryGetFactory(): ((options: OptionsBase) => IConfigCache) | undefined {
     const cache = getCloudflareCache();
     if (cache) {
       return options => new ExternalConfigCache(new CloudflareConfigCache(cache), options.logger);

--- a/src/cloudflare-worker/index.ts
+++ b/src/cloudflare-worker/index.ts
@@ -4,7 +4,7 @@ import type { IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions } from "
 import { PollingMode } from "../ConfigCatClientOptions";
 import { DefaultEventEmitter } from "../DefaultEventEmitter";
 import type { FlagOverrides, IQueryStringProvider, OverrideBehaviour } from "../FlagOverrides";
-import { createFlagOverridesFromQueryParams as createFlagOverridesFromQueryParamsCommon, getClient as getClientCommon } from "../index.pubternals.core";
+import { createFlagOverridesFromQueryParams as createFlagOverridesFromQueryParamsCommon, getClient as getClientInternal } from "../index.pubternals.core";
 import { setupPolyfills } from "../Polyfills";
 import { FetchApiConfigFetcher } from "../shared/FetchApiConfigFetcher";
 import CONFIGCAT_SDK_VERSION from "../Version";
@@ -25,12 +25,12 @@ setupPolyfills();
  * @param options Options for the specified polling mode.
  */
 export function getClient<TMode extends PollingMode | undefined>(sdkKey: string, pollingMode?: TMode, options?: OptionsForPollingMode<TMode>): IConfigCatClient {
-  return getClientCommon(sdkKey, pollingMode ?? PollingMode.AutoPoll, options, {
-    configFetcher: new FetchApiConfigFetcher(),
+  return getClientInternal(sdkKey, pollingMode ?? PollingMode.AutoPoll, options, {
     sdkType: "ConfigCat-UnifiedJS-CloudflareWorker",
     sdkVersion: CONFIGCAT_SDK_VERSION,
     eventEmitterFactory: () => new DefaultEventEmitter(),
     defaultCacheFactory: CloudflareConfigCache.tryGetFactory(),
+    configFetcherFactory: FetchApiConfigFetcher.getFactory(),
   });
 }
 

--- a/src/cloudflare-worker/index.ts
+++ b/src/cloudflare-worker/index.ts
@@ -29,8 +29,8 @@ export function getClient<TMode extends PollingMode | undefined>(sdkKey: string,
     sdkType: "ConfigCat-UnifiedJS-CloudflareWorker",
     sdkVersion: CONFIGCAT_SDK_VERSION,
     eventEmitterFactory: () => new DefaultEventEmitter(),
-    defaultCacheFactory: CloudflareConfigCache.tryGetFactory(),
-    configFetcherFactory: FetchApiConfigFetcher.getFactory(),
+    defaultCacheFactory: CloudflareConfigCache["tryGetFactory"](),
+    configFetcherFactory: FetchApiConfigFetcher["getFactory"](),
   });
 }
 
@@ -105,5 +105,9 @@ export type OptionsForPollingMode<TMode extends PollingMode | undefined> =
     TMode extends PollingMode.LazyLoad ? IJSLazyLoadingOptions :
     TMode extends undefined ? IJSAutoPollOptions :
     never;
+
+export { CloudflareConfigCache };
+
+export { FetchApiConfigFetcher };
 
 export * from "..";

--- a/src/deno/DenoHttpConfigFetcher.ts
+++ b/src/deno/DenoHttpConfigFetcher.ts
@@ -1,0 +1,5 @@
+import { FetchApiConfigFetcher } from "../browser";
+
+export class DenoHttpConfigFetcher extends FetchApiConfigFetcher {
+  protected override runsOnServerSide = true;
+}

--- a/src/deno/DenoHttpConfigFetcher.ts
+++ b/src/deno/DenoHttpConfigFetcher.ts
@@ -1,5 +1,16 @@
-import { FetchApiConfigFetcher } from "../browser";
+import type { OptionsBase } from "../ConfigCatClientOptions";
+import type { IConfigCatConfigFetcher } from "../ConfigFetcher";
+import { FetchApiConfigFetcher } from "../shared/FetchApiConfigFetcher";
 
+/// @ts-expect-error The `getFactory` static method is intentionally shadowed.
 export class DenoHttpConfigFetcher extends FetchApiConfigFetcher {
+  private static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
+    return options => {
+      const configFetcher = new DenoHttpConfigFetcher();
+      configFetcher["logger"] = options.logger;
+      return configFetcher;
+    };
+  }
+
   protected override runsOnServerSide = true;
 }

--- a/src/deno/index.ts
+++ b/src/deno/index.ts
@@ -3,8 +3,8 @@ import type { IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions } from "
 import { PollingMode } from "../ConfigCatClientOptions";
 import { DefaultEventEmitter } from "../DefaultEventEmitter";
 import { getClient as getClientInternal } from "../index.pubternals.core";
-import { FetchApiConfigFetcher } from "../shared/FetchApiConfigFetcher";
 import CONFIGCAT_SDK_VERSION from "../Version";
+import { DenoHttpConfigFetcher } from "./DenoHttpConfigFetcher";
 
 /* Package public API for Deno */
 
@@ -24,7 +24,7 @@ export function getClient<TMode extends PollingMode | undefined>(sdkKey: string,
       sdkType: "ConfigCat-UnifiedJS-Deno",
       sdkVersion: CONFIGCAT_SDK_VERSION,
       eventEmitterFactory: () => new DefaultEventEmitter(),
-      configFetcherFactory: FetchApiConfigFetcher["getFactory"](),
+      configFetcherFactory: DenoHttpConfigFetcher["getFactory"](),
     });
 }
 
@@ -49,6 +49,6 @@ export type OptionsForPollingMode<TMode extends PollingMode | undefined> =
   TMode extends undefined ? IDenoAutoPollOptions :
   never;
 
-export { FetchApiConfigFetcher };
+export { DenoHttpConfigFetcher };
 
 export * from "..";

--- a/src/deno/index.ts
+++ b/src/deno/index.ts
@@ -24,7 +24,7 @@ export function getClient<TMode extends PollingMode | undefined>(sdkKey: string,
       sdkType: "ConfigCat-UnifiedJS-Deno",
       sdkVersion: CONFIGCAT_SDK_VERSION,
       eventEmitterFactory: () => new DefaultEventEmitter(),
-      configFetcherFactory: FetchApiConfigFetcher.getFactory(),
+      configFetcherFactory: FetchApiConfigFetcher["getFactory"](),
     });
 }
 
@@ -48,5 +48,7 @@ export type OptionsForPollingMode<TMode extends PollingMode | undefined> =
   TMode extends PollingMode.LazyLoad ? IDenoLazyLoadingOptions :
   TMode extends undefined ? IDenoAutoPollOptions :
   never;
+
+export { FetchApiConfigFetcher };
 
 export * from "..";

--- a/src/deno/index.ts
+++ b/src/deno/index.ts
@@ -2,7 +2,7 @@ import type { IConfigCatClient } from "../ConfigCatClient";
 import type { IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions } from "../ConfigCatClientOptions";
 import { PollingMode } from "../ConfigCatClientOptions";
 import { DefaultEventEmitter } from "../DefaultEventEmitter";
-import { getClient as getClientCommon } from "../index.pubternals.core";
+import { getClient as getClientInternal } from "../index.pubternals.core";
 import { FetchApiConfigFetcher } from "../shared/FetchApiConfigFetcher";
 import CONFIGCAT_SDK_VERSION from "../Version";
 
@@ -19,12 +19,12 @@ import CONFIGCAT_SDK_VERSION from "../Version";
  * @param options Options for the specified polling mode.
  */
 export function getClient<TMode extends PollingMode | undefined>(sdkKey: string, pollingMode?: TMode, options?: OptionsForPollingMode<TMode>): IConfigCatClient {
-  return getClientCommon(sdkKey, pollingMode ?? PollingMode.AutoPoll, options,
+  return getClientInternal(sdkKey, pollingMode ?? PollingMode.AutoPoll, options,
     {
-      configFetcher: new FetchApiConfigFetcher(),
       sdkType: "ConfigCat-UnifiedJS-Deno",
       sdkVersion: CONFIGCAT_SDK_VERSION,
       eventEmitterFactory: () => new DefaultEventEmitter(),
+      configFetcherFactory: FetchApiConfigFetcher.getFactory(),
     });
 }
 

--- a/src/index.pubternals.core.ts
+++ b/src/index.pubternals.core.ts
@@ -1,6 +1,6 @@
 import { ConfigCatClient } from "./ConfigCatClient";
-import type { IConfigCatClient, IConfigCatKernel } from "./ConfigCatClient";
-import type { OptionsForPollingMode, PollingMode } from "./ConfigCatClientOptions";
+import type { IConfigCatClient } from "./ConfigCatClient";
+import type { IConfigCatKernel, OptionsForPollingMode, PollingMode } from "./ConfigCatClientOptions";
 import type { IConfigCatLogger, LogLevel } from "./ConfigCatLogger";
 import { ConfigCatConsoleLogger } from "./ConfigCatLogger";
 import type { FlagOverrides, IQueryStringProvider, OverrideBehaviour } from "./FlagOverrides";

--- a/src/index.pubternals.ts
+++ b/src/index.pubternals.ts
@@ -23,11 +23,3 @@ export { FetchResult, FetchStatus } from "./ConfigFetcher";
 export type { IEventEmitter, IEventProvider } from "./EventEmitter";
 
 export { DefaultEventEmitter } from "./DefaultEventEmitter";
-
-export { LocalStorageConfigCache } from "./browser/LocalStorageConfigCache";
-
-export { IndexedDBConfigCache } from "./shared/IndexedDBConfigCache";
-
-export { XmlHttpRequestConfigFetcher } from "./browser/XmlHttpRequestConfigFetcher";
-
-export { FetchApiConfigFetcher } from "./shared/FetchApiConfigFetcher";

--- a/src/index.pubternals.ts
+++ b/src/index.pubternals.ts
@@ -8,9 +8,7 @@ import { Setting } from "./ProjectConfig";
 
 export * from "./index.pubternals.core";
 
-export type { IConfigCatKernel } from "./ConfigCatClient";
-
-export type { OptionsBase } from "./ConfigCatClientOptions";
+export type { IConfigCatKernel, OptionsBase } from "./ConfigCatClientOptions";
 
 export type { IOverrideDataSource } from "./FlagOverrides";
 
@@ -20,9 +18,7 @@ export type { IConfigCache } from "./ConfigCatCache";
 
 export { ExternalConfigCache, InMemoryConfigCache } from "./ConfigCatCache";
 
-export type { FetchErrorCauses, IConfigFetcher, IFetchResponse } from "./ConfigFetcher";
-
-export { FetchError, FetchResult, FetchStatus } from "./ConfigFetcher";
+export { FetchResult, FetchStatus } from "./ConfigFetcher";
 
 export type { IEventEmitter, IEventProvider } from "./EventEmitter";
 
@@ -35,4 +31,3 @@ export { IndexedDBConfigCache } from "./shared/IndexedDBConfigCache";
 export { XmlHttpRequestConfigFetcher } from "./browser/XmlHttpRequestConfigFetcher";
 
 export { FetchApiConfigFetcher } from "./shared/FetchApiConfigFetcher";
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ export { FormattableLogMessage, LogLevel } from "./ConfigCatLogger";
 
 export type { IConfigCatCache } from "./ConfigCatCache";
 
+export type { FetchErrorCauses, IConfigCatConfigFetcher } from "./ConfigFetcher";
+
+export { FetchError, FetchRequest, FetchResponse } from "./ConfigFetcher";
+
 export type {
   ConditionTypeMap, ICondition, IConditionUnion, IConfig, IPercentageOption, IPrerequisiteFlagCondition,
   ISegment, ISegmentCondition, ISetting, ISettingUnion, ISettingValueContainer, ITargetingRule,

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -31,10 +31,10 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     this.proxy = options?.proxy;
   }
 
-  private handleResponse(response: http.IncomingMessage, isCustomUrl: boolean, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
+  private handleResponse(response: http.IncomingMessage, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
     try {
       const { statusCode, statusMessage: reasonPhrase } = response as { statusCode: number; statusMessage: string };
-      const headers = isCustomUrl ? this.getResponseHeaders(response) : getResponseHeadersDefault(response);
+      const headers = getResponseHeadersDefault(response);
 
       if (statusCode === 200) {
         const chunks: any[] = [];
@@ -113,7 +113,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
           this.logger.debug("NodeHttpConfigFetcher.fetchAsync() requestOptions: " + JSON.stringify(requestOptions));
         }
 
-        const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, isCustomUrl, resolve, reject))
+        const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, resolve, reject))
           .on("timeout", () => {
             try {
               clientRequest.destroy();
@@ -134,10 +134,6 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
 
   protected setRequestHeaders(requestOptions: { headers?: Record<string, http.OutgoingHttpHeader> }, headers: ReadonlyArray<[string, string]>): void {
     setRequestHeadersDefault(requestOptions, headers);
-  }
-
-  protected getResponseHeaders(httpResponse: http.IncomingMessage): [string, string][] {
-    return getResponseHeadersDefault(httpResponse);
   }
 }
 

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -92,7 +92,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
 
         const { lastETag, timeoutMs } = request;
 
-        const requestOptions: http.RequestOptions | https.RequestOptions = {
+        const requestOptions: (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> } = {
           agent,
           timeout: timeoutMs,
         };
@@ -126,7 +126,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     });
   }
 
-  protected setRequestHeaders(requestOptions: { headers?: http.OutgoingHttpHeaders }, headers: ReadonlyArray<[string, string]>): void {
+  protected setRequestHeaders(requestOptions: { headers?: Record<string, http.OutgoingHttpHeader> }, headers: ReadonlyArray<[string, string]>): void {
     if (headers.length) {
       const currentHeaders = requestOptions.headers ??= {};
       for (const [name, value] of headers) {

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -14,7 +14,7 @@ export interface INodeHttpConfigFetcherOptions {
 }
 
 export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
-  static getFactory(fetcherOptions?: INodeHttpConfigFetcherOptions): (options: OptionsBase) => IConfigCatConfigFetcher {
+  private static getFactory(fetcherOptions?: INodeHttpConfigFetcherOptions): (options: OptionsBase) => IConfigCatConfigFetcher {
     return options => {
       const configFetcher = new NodeHttpConfigFetcher(fetcherOptions);
       configFetcher.logger = options.logger;
@@ -126,7 +126,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     });
   }
 
-  private setRequestHeaders(requestOptions: { headers?: http.OutgoingHttpHeaders }, headers: ReadonlyArray<[string, string]>) {
+  protected setRequestHeaders(requestOptions: { headers?: http.OutgoingHttpHeaders }, headers: ReadonlyArray<[string, string]>): void {
     if (headers.length) {
       const currentHeaders = requestOptions.headers ??= {};
       for (const [name, value] of headers) {
@@ -142,7 +142,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     }
   }
 
-  private getResponseHeaders(httpResponse: http.IncomingMessage): [string, string][] {
+  protected getResponseHeaders(httpResponse: http.IncomingMessage): [string, string][] {
     const headers: [string, string][] = [];
     extractHeader("etag", httpResponse, headers);
     extractHeader("cf-ray", httpResponse, headers);

--- a/src/node/index.root.ts
+++ b/src/node/index.root.ts
@@ -1,4 +1,41 @@
+import type { IConfigCatClient } from "../ConfigCatClient";
+import type { OptionsForPollingMode, PollingMode } from "../ConfigCatClientOptions";
+import { getClient as getClientImpl } from ".";
+
 /* Package public API for Node.js or separate packages that implement a ConfigCat SDK. */
 
+/**
+ * Returns an instance of `ConfigCatClient` for the specified SDK Key.
+ * @remarks This method returns a single, shared instance per each distinct SDK Key.
+ * That is, a new client object is created only when there is none available for the specified SDK Key.
+ * Otherwise, the already created instance is returned (in which case the `pollingMode` and `options` arguments are ignored).
+ * So, please keep in mind that when you make multiple calls to this method using the same SDK Key, you may end up with multiple references to the same client object.
+ * @param sdkKey SDK Key to access the ConfigCat config.
+ * @param pollingMode The polling mode to use.
+ * @param options Options for the specified polling mode.
+ */
+export const getClient: <TMode extends PollingMode | undefined>(
+  sdkKey: string, pollingMode?: TMode, options?: OptionsForPollingMode<TMode>
+) => IConfigCatClient = getClientImpl;
+
+export { createConsoleLogger, createFlagOverridesFromMap, disposeAllClients } from "../index.pubternals.core";
+
+export type { INodeAutoPollOptions, INodeLazyLoadingOptions, INodeManualPollOptions } from ".";
+
+export type { IJSAutoPollOptions, IJSLazyLoadingOptions, IJSManualPollOptions } from "../browser";
+
+export type { OptionsForPollingMode };
+
+export { LocalStorageConfigCache } from "../browser/LocalStorageConfigCache";
+
+export { IndexedDBConfigCache } from "../shared/IndexedDBConfigCache";
+
+export { XmlHttpRequestConfigFetcher } from "../browser/XmlHttpRequestConfigFetcher";
+
+export { FetchApiConfigFetcher } from "../shared/FetchApiConfigFetcher";
+
+export { NodeHttpConfigFetcher } from "./NodeHttpConfigFetcher";
+
 export * as Internals from "../index.pubternals";
-export * from ".";
+
+export * from "..";

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "events";
 import type { IConfigCatClient } from "../ConfigCatClient";
 import type { IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions } from "../ConfigCatClientOptions";
 import { PollingMode } from "../ConfigCatClientOptions";
-import { getClient as getClientCommon } from "../index.pubternals.core";
+import { getClient as getClientInternal } from "../index.pubternals.core";
 import CONFIGCAT_SDK_VERSION from "../Version";
 import type { INodeHttpConfigFetcherOptions } from "./NodeHttpConfigFetcher";
 import { NodeHttpConfigFetcher } from "./NodeHttpConfigFetcher";
@@ -20,12 +20,12 @@ import { NodeHttpConfigFetcher } from "./NodeHttpConfigFetcher";
  * @param options Options for the specified polling mode.
  */
 export function getClient<TMode extends PollingMode | undefined>(sdkKey: string, pollingMode?: TMode, options?: OptionsForPollingMode<TMode>): IConfigCatClient {
-  return getClientCommon(sdkKey, pollingMode ?? PollingMode.AutoPoll, options,
+  return getClientInternal(sdkKey, pollingMode ?? PollingMode.AutoPoll, options,
     {
-      configFetcher: new NodeHttpConfigFetcher(options),
       sdkType: "ConfigCat-UnifiedJS-Node",
       sdkVersion: CONFIGCAT_SDK_VERSION,
       eventEmitterFactory: () => new EventEmitter(),
+      configFetcherFactory: NodeHttpConfigFetcher.getFactory(options),
     });
 }
 

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -25,7 +25,7 @@ export function getClient<TMode extends PollingMode | undefined>(sdkKey: string,
       sdkType: "ConfigCat-UnifiedJS-Node",
       sdkVersion: CONFIGCAT_SDK_VERSION,
       eventEmitterFactory: () => new EventEmitter(),
-      configFetcherFactory: NodeHttpConfigFetcher.getFactory(options),
+      configFetcherFactory: NodeHttpConfigFetcher["getFactory"](options),
     });
 }
 
@@ -49,5 +49,7 @@ export type OptionsForPollingMode<TMode extends PollingMode | undefined> =
   TMode extends PollingMode.LazyLoad ? INodeLazyLoadingOptions :
   TMode extends undefined ? INodeAutoPollOptions :
   never;
+
+export { NodeHttpConfigFetcher };
 
 export * from "..";

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -1,46 +1,58 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
-import type { IConfigFetcher, IFetchResponse } from "../ConfigFetcher";
-import { FetchError } from "../ConfigFetcher";
+import type { LoggerWrapper } from "../ConfigCatLogger";
+import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import { FetchError, FetchResponse } from "../ConfigFetcher";
 
-export class FetchApiConfigFetcher implements IConfigFetcher {
-  async fetchLogic(options: OptionsBase, lastEtag: string | null): Promise<IFetchResponse> {
+export class FetchApiConfigFetcher implements IConfigCatConfigFetcher {
+  static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
+    return options => {
+      const configFetcher = new FetchApiConfigFetcher();
+      configFetcher.logger = options.logger;
+      return configFetcher;
+    };
+  }
+
+  private logger?: LoggerWrapper;
+
+  async fetchAsync(request: FetchRequest): Promise<FetchResponse> {
+    this.logger?.debug("FetchApiConfigFetcher.fetchAsync() called.");
+
+    let { url } = request;
+    const { lastETag, timeoutMs } = request;
+
+    if (lastETag) {
+      // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header,
+      // we can transform this query param to the header in our CDN provider.
+      url += "&ccetag=" + encodeURIComponent(lastETag);
+    }
+
     const requestInit: RequestInit = { method: "GET" };
-    let cleanup: () => void;
+    // NOTE: It's intentional that we don't specify the If-None-Match header.
+    // The browser automatically handles it, adding it manually would cause an unnecessary CORS OPTIONS request.
+    // In case the browser doesn't handle it, we are transforming the ccetag query parameter to the If-None-Match header
+    this.setRequestHeaders(requestInit as { headers?: [string, string][] }, request.headers);
+
+    let cleanup: (() => void) | undefined;
 
     // NOTE: Older Chromium versions (e.g. the one used in our tests) may not support AbortController.
     if (typeof AbortController !== "undefined") {
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), options.requestTimeoutMs);
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
       requestInit.signal = controller.signal;
       cleanup = () => clearTimeout(timeoutId);
-    } else {
-      cleanup = () => { };
     }
 
     try {
-      let url = options.getUrl();
-      if (lastEtag) {
-        // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header,
-        // we can transform this query param to the header in our CDN provider.
-        url += "&ccetag=" + encodeURIComponent(lastEtag);
-      }
-      // NOTE: It's intentional that we don't specify the If-None-Match header.
-      // The browser automatically handles it, adding it manually would cause an unnecessary CORS OPTIONS request.
-      // In case the browser doesn't handle it, we are transforming the ccetag query parameter to the If-None-Match header
       const response = await fetch(url, requestInit);
 
       const { status: statusCode, statusText: reasonPhrase } = response;
-      if (statusCode === 200) {
-        const body = await response.text();
-        const eTag = response.headers.get("ETag") ?? void 0;
-        return { statusCode, reasonPhrase, eTag, body };
-      } else {
-        return { statusCode, reasonPhrase };
-      }
+      const headers = this.getResponseHeaders(response);
+      const body = statusCode === 200 ? await response.text() : void 0;
+      return new FetchResponse(statusCode, reasonPhrase, headers, body);
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") {
         if (requestInit.signal?.aborted) {
-          throw new FetchError("timeout", options.requestTimeoutMs);
+          throw new FetchError("timeout", timeoutMs);
         } else {
           throw new FetchError("abort");
         }
@@ -48,7 +60,27 @@ export class FetchApiConfigFetcher implements IConfigFetcher {
 
       throw new FetchError("failure", err);
     } finally {
-      cleanup();
+      cleanup?.();
+    }
+  }
+
+  private setRequestHeaders(requestInit: { headers?: [string, string][] }, headers: ReadonlyArray<[string, string]>) {
+    if (headers.length) {
+      (requestInit.headers ??= []).push(...headers);
+    }
+  }
+
+  private getResponseHeaders(httpResponse: Response): [string, string][] {
+    const headers: [string, string][] = [];
+    extractHeader("ETag", httpResponse, headers);
+    extractHeader("CF-RAY", httpResponse, headers);
+    return headers;
+
+    function extractHeader(name: string, httpResponse: Response, headers: [string, string][]) {
+      const value = httpResponse.headers.get(name);
+      if (value != null) {
+        headers.push([name, value]);
+      }
     }
   }
 }

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -55,7 +55,7 @@ export class FetchApiConfigFetcher implements IConfigCatConfigFetcher {
       const response = await fetch(url, requestInit);
 
       const { status: statusCode, statusText: reasonPhrase } = response;
-      const headers = isCustomUrl ? this.getResponseHeaders(response) : getResponseHeadersDefault(response);
+      const headers = getResponseHeadersDefault(response);
       const body = statusCode === 200 ? await response.text() : void 0;
       return new FetchResponse(statusCode, reasonPhrase, headers, body);
     } catch (err) {
@@ -77,10 +77,6 @@ export class FetchApiConfigFetcher implements IConfigCatConfigFetcher {
     if (this.runsOnServerSide) {
       setRequestHeadersDefault(requestInit, headers);
     }
-  }
-
-  protected getResponseHeaders(httpResponse: Response): [string, string][] {
-    return getResponseHeadersDefault(httpResponse);
   }
 }
 

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -4,7 +4,7 @@ import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { FetchError, FetchResponse } from "../ConfigFetcher";
 
 export class FetchApiConfigFetcher implements IConfigCatConfigFetcher {
-  static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
+  private static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
     return options => {
       const configFetcher = new FetchApiConfigFetcher();
       configFetcher.logger = options.logger;
@@ -64,13 +64,13 @@ export class FetchApiConfigFetcher implements IConfigCatConfigFetcher {
     }
   }
 
-  private setRequestHeaders(requestInit: { headers?: [string, string][] }, headers: ReadonlyArray<[string, string]>) {
+  protected setRequestHeaders(requestInit: { headers?: [string, string][] }, headers: ReadonlyArray<[string, string]>): void {
     if (headers.length) {
       (requestInit.headers ??= []).push(...headers);
     }
   }
 
-  private getResponseHeaders(httpResponse: Response): [string, string][] {
+  protected getResponseHeaders(httpResponse: Response): [string, string][] {
     const headers: [string, string][] = [];
     extractHeader("ETag", httpResponse, headers);
     extractHeader("CF-RAY", httpResponse, headers);

--- a/src/shared/IndexedDBConfigCache.ts
+++ b/src/shared/IndexedDBConfigCache.ts
@@ -7,7 +7,7 @@ const OBJECT_STORE_NAME = "configCache";
 type DBConnectionFactory = () => Promise<IDBDatabase>;
 
 export class IndexedDBConfigCache implements IConfigCatCache {
-  static tryGetFactory(): ((options: OptionsBase) => IConfigCache) | undefined {
+  private static tryGetFactory(): ((options: OptionsBase) => IConfigCache) | undefined {
     const dbConnectionFactory = getDBConnectionFactory();
     if (dbConnectionFactory) {
       return options => new ExternalConfigCache(new IndexedDBConfigCache(dbConnectionFactory), options.logger);

--- a/test/ConfigCatClientCacheTests.ts
+++ b/test/ConfigCatClientCacheTests.ts
@@ -11,15 +11,15 @@ describe("ConfigCatClientCache", () => {
 
     const sdkKey = "123";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options = createManualPollOptions(sdkKey, void 0, configCatKernel);
 
     const cache = new ConfigCatClientCache();
 
     // Act
 
-    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options, configCatKernel);
-    const [client2, instanceAlreadyCreated2] = cache.getOrCreate(options, configCatKernel);
+    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options);
+    const [client2, instanceAlreadyCreated2] = cache.getOrCreate(options);
 
     // Assert
 
@@ -49,7 +49,7 @@ describe("ConfigCatClientCache", () => {
 
     const sdkKey = "123";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options = createAutoPollOptions(sdkKey, void 0, configCatKernel);
 
     const cache = new ConfigCatClientCache();
@@ -60,7 +60,7 @@ describe("ConfigCatClientCache", () => {
 
     await gc();
 
-    const [client2, instanceAlreadyCreated2] = cache.getOrCreate(options, configCatKernel);
+    const [client2, instanceAlreadyCreated2] = cache.getOrCreate(options);
 
     // Assert
 
@@ -81,12 +81,12 @@ describe("ConfigCatClientCache", () => {
 
     const sdkKey = "123";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options = createManualPollOptions(sdkKey, void 0, configCatKernel);
 
     const cache = new ConfigCatClientCache();
 
-    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options, configCatKernel);
+    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options);
 
     // Act
 
@@ -109,15 +109,15 @@ describe("ConfigCatClientCache", () => {
 
     const sdkKey = "123";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options = createManualPollOptions(sdkKey, void 0, configCatKernel);
 
     const cache = new ConfigCatClientCache();
 
-    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options, configCatKernel);
+    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options);
     cache.remove(sdkKey, client1["cacheToken"]);
 
-    const [client2, instanceAlreadyCreated2] = cache.getOrCreate(options, configCatKernel);
+    const [client2, instanceAlreadyCreated2] = cache.getOrCreate(options);
 
     // Act
 
@@ -152,7 +152,7 @@ describe("ConfigCatClientCache", () => {
 
     const sdkKey = "123";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options = createManualPollOptions(sdkKey, void 0, configCatKernel);
 
     const cache = new ConfigCatClientCache();
@@ -180,12 +180,12 @@ describe("ConfigCatClientCache", () => {
 
     const sdkKey = "123";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options = createManualPollOptions(sdkKey, void 0, configCatKernel);
 
     const cache = new ConfigCatClientCache();
 
-    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options, configCatKernel);
+    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options);
 
     // Act
 
@@ -217,13 +217,13 @@ describe("ConfigCatClientCache", () => {
     const sdkKey1 = "123";
     const sdkKey2 = "456";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options1 = createManualPollOptions(sdkKey1, void 0, configCatKernel);
     const options2 = createManualPollOptions(sdkKey2, void 0, configCatKernel);
 
     const cache = new ConfigCatClientCache();
 
-    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options1, configCatKernel);
+    const [client1, instanceAlreadyCreated1] = cache.getOrCreate(options1);
     const [client2, instanceAlreadyCreated2, cacheCountBefore] = getOrCreateClientWeakRef(cache, options2, configCatKernel);
 
     await gc();
@@ -250,6 +250,6 @@ describe("ConfigCatClientCache", () => {
 });
 
 function getOrCreateClientWeakRef(cache: ConfigCatClientCache, options: any, configCatKernel: any): [WeakRef<ConfigCatClient>, boolean, number] {
-  const [client, instanceAlreadyCreated] = cache.getOrCreate(options, configCatKernel);
+  const [client, instanceAlreadyCreated] = cache.getOrCreate(options);
   return [new WeakRef(client), instanceAlreadyCreated, cache.getAliveCount()];
 }

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -3,10 +3,10 @@ import { createAutoPollOptions, createKernel, createLazyLoadOptions, createManua
 import { platform } from "./helpers/platform";
 import { allowEventLoop } from "./helpers/utils";
 import { AutoPollConfigService } from "#lib/AutoPollConfigService";
-import { ConfigCatClient, IConfigCatClient, IConfigCatKernel } from "#lib/ConfigCatClient";
-import { AutoPollOptions, IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions, IOptions, LazyLoadOptions, ManualPollOptions, OptionsBase, PollingMode } from "#lib/ConfigCatClientOptions";
+import { ConfigCatClient, IConfigCatClient } from "#lib/ConfigCatClient";
+import { AutoPollOptions, IAutoPollOptions, IConfigCatKernel, ILazyLoadingOptions, IManualPollOptions, IOptions, LazyLoadOptions, ManualPollOptions, OptionsBase, PollingMode } from "#lib/ConfigCatClientOptions";
 import { LogLevel } from "#lib/ConfigCatLogger";
-import { IFetchResponse } from "#lib/ConfigFetcher";
+import { FetchResponse } from "#lib/ConfigFetcher";
 import { ClientCacheState, ConfigServiceBase, IConfigService, RefreshErrorCode, RefreshResult } from "#lib/ConfigServiceBase";
 import { MapOverrideDataSource, OverrideBehaviour } from "#lib/FlagOverrides";
 import { IProvidesHooks } from "#lib/Hooks";
@@ -40,7 +40,7 @@ describe("ConfigCatClient", () => {
   ]) {
     it(`SDK key format should be validated - sdkKey: ${sdkKey} | customBaseUrl: ${customBaseUrl}`, () => {
       const options: IManualPollOptions = customBaseUrl ? { baseUrl: "https://my-configcat-proxy" } : {};
-      const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+      const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
 
       if (isValid) {
         ConfigCatClient.get(sdkKey, PollingMode.ManualPoll, options, configCatKernel).dispose();
@@ -53,7 +53,7 @@ describe("ConfigCatClient", () => {
   }
 
   it("Initialization With AutoPollOptions should create an instance, getValueAsync works", async () => {
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
@@ -70,7 +70,7 @@ describe("ConfigCatClient", () => {
 
   it("Initialization With LazyLoadOptions should create an instance, getValueAsync works", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options: LazyLoadOptions = createLazyLoadOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
@@ -86,7 +86,7 @@ describe("ConfigCatClient", () => {
 
   it("Initialization With ManualPollOptions should create an instance, getValueAsync works", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options: ManualPollOptions = createManualPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
@@ -103,7 +103,7 @@ describe("ConfigCatClient", () => {
 
   it("Initialization With ManualPollOptions should create an instance", (done) => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options: ManualPollOptions = createManualPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
@@ -118,7 +118,7 @@ describe("ConfigCatClient", () => {
 
   it("Initialization With AutoPollOptions should create an instance", (done) => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
@@ -132,7 +132,7 @@ describe("ConfigCatClient", () => {
 
   it("Initialization With LazyLoadOptions should create an instance", (done) => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithNullNewConfig() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithNullNewConfig() });
     const options: LazyLoadOptions = createLazyLoadOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
@@ -146,7 +146,7 @@ describe("ConfigCatClient", () => {
 
   it("getValueAsync() works without userObject", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
@@ -165,7 +165,7 @@ describe("ConfigCatClient", () => {
 
   it("getAllKeysAsync() works", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithTwoKeys() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithTwoKeys() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
@@ -179,7 +179,7 @@ describe("ConfigCatClient", () => {
 
   it("getAllKeysAsync() works - without config", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithNullNewConfig() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithNullNewConfig() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null, maxInitWaitTimeSeconds: 0 }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
@@ -197,7 +197,7 @@ describe("ConfigCatClient", () => {
     const defaultValue = false;
 
     const configCache = new FakeCache();
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher(), defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher(), defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -241,7 +241,7 @@ describe("ConfigCatClient", () => {
     const configFetcherClass = FakeConfigFetcherWithTwoKeys;
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, Config.deserialize(configFetcherClass.configJson), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
-    const configCatKernel = createKernel({ configFetcher: new configFetcherClass(), defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new configFetcherClass(), defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -285,7 +285,7 @@ describe("ConfigCatClient", () => {
     const configFetcherClass = FakeConfigFetcherWithTwoKeys;
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, Config.deserialize(configFetcherClass.configJson), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
-    const configCatKernel = createKernel({ configFetcher: new configFetcherClass(), defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new configFetcherClass(), defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -329,7 +329,7 @@ describe("ConfigCatClient", () => {
     const configFetcherClass = FakeConfigFetcherWithRules;
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, Config.deserialize(configFetcherClass.configJson), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
-    const configCatKernel = createKernel({ configFetcher: new configFetcherClass(), defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new configFetcherClass(), defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -376,7 +376,7 @@ describe("ConfigCatClient", () => {
     const configFetcherClass = FakeConfigFetcherWithPercentageOptions;
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, Config.deserialize(configFetcherClass.configJson), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
-    const configCatKernel = createKernel({ configFetcher: new configFetcherClass(), defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new configFetcherClass(), defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -422,7 +422,7 @@ describe("ConfigCatClient", () => {
     const configFetcherClass = FakeConfigFetcherWithTwoKeys;
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, Config.deserialize(configFetcherClass.configJson), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
-    const configCatKernel = createKernel({ configFetcher: new configFetcherClass(), defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new configFetcherClass(), defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -478,7 +478,7 @@ describe("ConfigCatClient", () => {
     const configFetcherClass = FakeConfigFetcherWithTwoKeys;
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, Config.deserialize(configFetcherClass.configJson), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
-    const configCatKernel = createKernel({ configFetcher: new configFetcherClass(), defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new configFetcherClass(), defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -531,7 +531,7 @@ describe("ConfigCatClient", () => {
     const configFetcherClass = FakeConfigFetcherWithTwoKeys;
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, Config.deserialize(configFetcherClass.configJson), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
-    const configCatKernel = createKernel({ configFetcher: new configFetcherClass(), defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new configFetcherClass(), defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -590,7 +590,7 @@ describe("ConfigCatClient", () => {
 
   it("Initialization With AutoPollOptions - config changed in every fetch - should fire configChanged every polling iteration", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithAlwaysVariableEtag() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithAlwaysVariableEtag() });
     let configChangedEventCount = 0;
     const pollIntervalSeconds = 1;
     const userOptions: IAutoPollOptions = {
@@ -609,7 +609,7 @@ describe("ConfigCatClient", () => {
 
   it("Initialization With AutoPollOptions - config doesn't change - should fire configChanged only once", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     let configChangedEventCount = 0;
     const pollIntervalSeconds = 1;
     const userOptions: IAutoPollOptions = {
@@ -630,7 +630,7 @@ describe("ConfigCatClient", () => {
 
     const maxInitWaitTimeSeconds = 2;
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher(500) });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher(500) });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { maxInitWaitTimeSeconds }, configCatKernel);
 
     const startTime: number = getMonotonicTimeMs();
@@ -654,7 +654,7 @@ describe("ConfigCatClient", () => {
       const configFetcher = new FakeConfigFetcherBase(null, configFetchDelay, () =>
         statusCode ? { statusCode, reasonPhrase: "x" } : (() => { throw "network error"; })());
 
-      const configCatKernel = createKernel({ configFetcher });
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
       const options: AutoPollOptions = createAutoPollOptions("APIKEY", { maxInitWaitTimeSeconds }, configCatKernel);
 
       const startTime: number = getMonotonicTimeMs();
@@ -675,7 +675,7 @@ describe("ConfigCatClient", () => {
 
     const maxInitWaitTimeSeconds = 1;
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithNullNewConfig(10000) });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithNullNewConfig(10000) });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { maxInitWaitTimeSeconds }, configCatKernel);
 
     const startTime: number = getMonotonicTimeMs();
@@ -698,10 +698,10 @@ describe("ConfigCatClient", () => {
       reasonPhrase: "",
       eTag: (lastETag as any | 0) + 1 + "",
       body: lastConfig,
-    } as IFetchResponse));
+    } as FetchResponse));
 
     it("AutoPoll - should wait", async () => {
-      const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+      const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
       const options: AutoPollOptions = createAutoPollOptions("APIKEY", void 0, configCatKernel);
 
       const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
@@ -716,7 +716,7 @@ describe("ConfigCatClient", () => {
     it("AutoPoll - should wait for maxInitWaitTimeSeconds", async () => {
 
       const configFetcher = new FakeConfigFetcherWithNullNewConfig(maxInitWaitTimeSeconds * 2 * 1000);
-      const configCatKernel = createKernel({ configFetcher });
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
       const options: AutoPollOptions = createAutoPollOptions("APIKEY", { maxInitWaitTimeSeconds }, configCatKernel);
 
       const startTime: number = getMonotonicTimeMs();
@@ -745,8 +745,8 @@ describe("ConfigCatClient", () => {
         reasonPhrase: "",
         eTag: (lastETag as any | 0) + 1 + "",
         body: lastConfig,
-      } as IFetchResponse));
-      const configCatKernel = createKernel({ configFetcher });
+      } as FetchResponse));
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
       const options: AutoPollOptions = createAutoPollOptions("APIKEY", {
         maxInitWaitTimeSeconds: maxInitWaitTimeSeconds,
         cache: new FakeExternalCacheWithInitialData(120_000),
@@ -773,7 +773,7 @@ describe("ConfigCatClient", () => {
 
     it("LazyLoad - return cached", async () => {
 
-      const configCatKernel = createKernel({ configFetcher });
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
       const options: LazyLoadOptions = createLazyLoadOptions("APIKEY", {
         cache: new FakeExternalCacheWithInitialData(),
       }, configCatKernel);
@@ -789,7 +789,7 @@ describe("ConfigCatClient", () => {
 
     it("LazyLoad - expired, return cached", async () => {
 
-      const configCatKernel = createKernel({ configFetcher });
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
       const options: LazyLoadOptions = createLazyLoadOptions("APIKEY", {
         cache: new FakeExternalCacheWithInitialData(120_000),
       }, configCatKernel);
@@ -805,7 +805,7 @@ describe("ConfigCatClient", () => {
 
     it("ManualPoll - return cached", async () => {
 
-      const configCatKernel = createKernel({ configFetcher });
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
       const options: ManualPollOptions = createManualPollOptions("APIKEY", {
         cache: new FakeExternalCacheWithInitialData(),
       }, configCatKernel);
@@ -823,7 +823,7 @@ describe("ConfigCatClient", () => {
     });
 
     it("ManualPoll - flag override - local only", async () => {
-      const configCatKernel = createKernel({ configFetcher: configFetcher });
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
       const options: ManualPollOptions = createManualPollOptions("localhost", {
         flagOverrides: {
           dataSource: new MapOverrideDataSource({
@@ -848,7 +848,7 @@ describe("ConfigCatClient", () => {
 
   it("getValueAsync - User.Identifier is an empty string - should return evaluated value", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithTwoKeysAndRules() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithTwoKeysAndRules() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", void 0, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -863,7 +863,7 @@ describe("ConfigCatClient", () => {
 
   it("getValueAsync - User.Identifier can be non empty string - should return evaluated value", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithTwoKeysAndRules() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithTwoKeysAndRules() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", void 0, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -878,7 +878,7 @@ describe("ConfigCatClient", () => {
 
   it("getValueAsync - case sensitive key tests", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithTwoCaseSensitiveKeys() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithTwoCaseSensitiveKeys() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", void 0, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -896,7 +896,7 @@ describe("ConfigCatClient", () => {
   });
 
   it("getValueAsync - case sensitive attribute tests", async () => {
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithTwoCaseSensitiveKeys() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithTwoCaseSensitiveKeys() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", void 0, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -920,7 +920,7 @@ describe("ConfigCatClient", () => {
 
   it("getAllValuesAsync - works", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithTwoKeys() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithTwoKeys() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", void 0, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -938,7 +938,7 @@ describe("ConfigCatClient", () => {
 
   it("getAllValuesAsync - without config - return empty array", async () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithNullNewConfig() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithNullNewConfig() });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null, maxInitWaitTimeSeconds: 0 }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -958,7 +958,7 @@ describe("ConfigCatClient", () => {
   it("Initialization With LazyLoadOptions - multiple getValueAsync should not cause multiple config fetches", async () => {
 
     const configFetcher = new FakeConfigFetcher(500);
-    const configCatKernel = createKernel({ configFetcher });
+    const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
     const options: LazyLoadOptions = createLazyLoadOptions("APIKEY", void 0, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -971,7 +971,7 @@ describe("ConfigCatClient", () => {
   it("Initialization With LazyLoadOptions - multiple getValue calls should not cause multiple config fetches", done => {
 
     const configFetcher = new FakeConfigFetcher(500);
-    const configCatKernel = createKernel({ configFetcher });
+    const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
     const options: LazyLoadOptions = createLazyLoadOptions("APIKEY", void 0, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -997,7 +997,7 @@ describe("ConfigCatClient", () => {
     const configFetcher = new FakeConfigFetcher(500);
     const configJson = "{\"f\": { \"debug\": { \"v\": { \"b\": false }, \"i\": \"abcdefgh\", \"t\": 0, \"p\": [], \"r\": [] } } }";
     const configCache = new FakeCache(new ProjectConfig(configJson, Config.deserialize(configJson), ProjectConfig.generateTimestamp() - 10000000, "etag2"));
-    const configCatKernel = createKernel({ configFetcher, defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher, defaultCacheFactory: () => configCache });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { maxInitWaitTimeSeconds: 10 }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -1012,7 +1012,7 @@ describe("ConfigCatClient", () => {
     const configFetcher = new FakeConfigFetcher(500);
     const configJson = "{\"f\": { \"debug\": { \"v\": { \"b\": false }, \"i\": \"abcdefgh\", \"t\": 0, \"p\": [], \"r\": [] } } }";
     const configCache = new FakeCache(new ProjectConfig(configJson, Config.deserialize(configJson), ProjectConfig.generateTimestamp() - 10000000, "etag2"));
-    const configCatKernel = createKernel({ configFetcher, defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher, defaultCacheFactory: () => configCache });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { maxInitWaitTimeSeconds: 10 }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
@@ -1025,7 +1025,7 @@ describe("ConfigCatClient", () => {
   it("Dispose should stop the client in every scenario", done => {
 
     const configFetcher = new FakeConfigFetcher(500);
-    const configCatKernel = createKernel({ configFetcher });
+    const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { pollIntervalSeconds: 2 }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     client.dispose();
@@ -1045,7 +1045,7 @@ describe("ConfigCatClient", () => {
 
       const logger = new FakeLogger(LogLevel.Debug);
 
-      const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+      const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
       const options: IManualPollOptions = { logger };
 
       // Act
@@ -1083,7 +1083,7 @@ describe("ConfigCatClient", () => {
 
     const sdkKey = "test-67890123456789012/1234567890123456789012";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
 
     const client1 = ConfigCatClient.get(sdkKey, PollingMode.ManualPoll, null, configCatKernel);
 
@@ -1108,7 +1108,7 @@ describe("ConfigCatClient", () => {
 
     const sdkKey = "test-67890123456789012/1234567890123456789012";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
 
     const client1 = ConfigCatClient.get(sdkKey, PollingMode.ManualPoll, null, configCatKernel);
 
@@ -1148,7 +1148,7 @@ describe("ConfigCatClient", () => {
 
     const sdkKey1 = "test1-7890123456789012/1234567890123456789012", sdkKey2 = "test2-7890123456789012/1234567890123456789012";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
 
     const client1 = ConfigCatClient.get(sdkKey1, PollingMode.AutoPoll, null, configCatKernel);
     const client2 = ConfigCatClient.get(sdkKey2, PollingMode.ManualPoll, null, configCatKernel);
@@ -1184,7 +1184,7 @@ describe("ConfigCatClient", () => {
     const sdkKey1 = "test1-7890123456789012/1234567890123456789012", sdkKey2 = "test2-7890123456789012/1234567890123456789012";
 
     const logger = new FakeLogger(LogLevel.Debug);
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
 
     function createClients() {
       ConfigCatClient.get(sdkKey1, PollingMode.AutoPoll, { logger, maxInitWaitTimeSeconds: 0 }, configCatKernel);
@@ -1230,7 +1230,7 @@ describe("ConfigCatClient", () => {
 
     const sdkKey1 = "test1-7890123456789012/1234567890123456789012";
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
 
     function createClients() {
       const client = ConfigCatClient.get(sdkKey1, PollingMode.AutoPoll, { maxInitWaitTimeSeconds: 0 }, configCatKernel);
@@ -1272,9 +1272,9 @@ describe("ConfigCatClient", () => {
         reasonPhrase: "OK",
         eTag: (lastETag as any | 0) + 1 + "",
         body: lastConfig,
-      } as IFetchResponse));
+      } as FetchResponse));
       const configCache = new FakeCache();
-      const configCatKernel = createKernel({ configFetcher, defaultCacheFactory: () => configCache });
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher, defaultCacheFactory: () => configCache });
       const options = optionsFactory("APIKEY", configCatKernel, true);
       const client = new ConfigCatClient(options, configCatKernel);
       const configService = client["configService"] as ConfigServiceBase<OptionsBase>;
@@ -1339,10 +1339,10 @@ describe("ConfigCatClient", () => {
         reasonPhrase: "OK",
         eTag: (lastETag as any | 0) + 1 + "",
         body: lastConfig,
-      } as IFetchResponse));
+      } as FetchResponse));
 
       const configCache = new FakeCache();
-      const configCatKernel = createKernel({ configFetcher, defaultCacheFactory: () => configCache });
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher, defaultCacheFactory: () => configCache });
       const options = optionsFactory("APIKEY", configCatKernel, false);
       const client = new ConfigCatClient(options, configCatKernel);
       const configService = client["configService"] as ConfigServiceBase<OptionsBase>;
@@ -1425,7 +1425,7 @@ describe("ConfigCatClient", () => {
 
       const configFetcher = new FakeConfigFetcherWithTwoKeys();
       const configCache = new FakeCache();
-      const configCatKernel = createKernel({ configFetcher, defaultCacheFactory: () => configCache });
+      const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher, defaultCacheFactory: () => configCache });
       const userOptions: IManualPollOptions = addListenersViaOptions ? { setupHooks } : {};
       const options = createManualPollOptions("APIKEY", userOptions, configCatKernel);
 
@@ -1510,7 +1510,7 @@ describe("ConfigCatClient", () => {
 
     const configFetcher = new FakeConfigFetcherBase(null, 100, (lastConfig, lastETag) => { throw errorException; });
     const configCache = new FakeCache();
-    const configCatKernel = createKernel({ configFetcher, defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher, defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
 
     const client = new ConfigCatClient(options, configCatKernel);
@@ -1531,7 +1531,7 @@ describe("ConfigCatClient", () => {
 
     const configFetcher = new FakeConfigFetcherBase(null, 100, (lastConfig, lastETag) => { throw errorException; });
     const configCache = new FakeCache();
-    const configCatKernel = createKernel({ configFetcher, defaultCacheFactory: () => configCache });
+    const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher, defaultCacheFactory: () => configCache });
     const options = createManualPollOptions("APIKEY", void 0, configCatKernel);
 
     const client = new ConfigCatClient(options, configCatKernel);
@@ -1578,7 +1578,7 @@ describe("ConfigCatClient", () => {
       it(`${PollingMode[pollingMode]} - snapshot() should correctly report client cache state - ${cacheType} - ${initialCacheState}`, async () => {
         const configFetcher = new FakeConfigFetcher(100);
         const configJson = configFetcher.defaultConfigJson;
-        const configCatKernel = createKernel({ configFetcher });
+        const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
         const asyncCacheDelayMs = 1, expirationSeconds = 5;
 
         const clientOptions: IOptions = {

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -639,7 +639,7 @@ describe("ConfigCatClient", () => {
     const elapsedMilliseconds: number = getMonotonicTimeMs() - startTime;
 
     assert.isAtLeast(elapsedMilliseconds, 500 - 25); // 25 ms for tolerance
-    assert.isAtMost(elapsedMilliseconds, maxInitWaitTimeSeconds * 1000 + 100); // 100 ms for tolerance
+    assert.isAtMost(elapsedMilliseconds, maxInitWaitTimeSeconds * 1000 + 125); // 125 ms for tolerance
     assert.equal(actualValue, true);
 
     client.dispose();
@@ -663,7 +663,7 @@ describe("ConfigCatClient", () => {
       const elapsedMilliseconds: number = getMonotonicTimeMs() - startTime;
 
       assert.isAtLeast(elapsedMilliseconds, 500 - 25); // 25 ms for tolerance
-      assert.isAtMost(elapsedMilliseconds, configFetchDelay * 2 + 100); // 100 ms for tolerance
+      assert.isAtMost(elapsedMilliseconds, configFetchDelay * 2 + 125); // 125 ms for tolerance
       assert.equal(actualDetails.isDefaultValue, true);
       assert.equal(actualDetails.value, false);
 
@@ -684,7 +684,7 @@ describe("ConfigCatClient", () => {
     const elapsedMilliseconds: number = getMonotonicTimeMs() - startTime;
 
     assert.isAtLeast(elapsedMilliseconds, (maxInitWaitTimeSeconds * 1000) - 25); // 25 ms for tolerance
-    assert.isAtMost(elapsedMilliseconds, (maxInitWaitTimeSeconds * 1000) + 100); // 100 ms for tolerance
+    assert.isAtMost(elapsedMilliseconds, (maxInitWaitTimeSeconds * 1000) + 125); // 125 ms for tolerance
     assert.equal(actualValue, false);
 
     client.dispose();
@@ -725,7 +725,7 @@ describe("ConfigCatClient", () => {
       const elapsedMilliseconds: number = getMonotonicTimeMs() - startTime;
 
       assert.isAtLeast(elapsedMilliseconds, (maxInitWaitTimeSeconds * 1000) - 25); // 25 ms for tolerance
-      assert.isAtMost(elapsedMilliseconds, (maxInitWaitTimeSeconds * 1000) + 100); // 100 ms for tolerance
+      assert.isAtMost(elapsedMilliseconds, (maxInitWaitTimeSeconds * 1000) + 125); // 125 ms for tolerance
 
       assert.equal(state, ClientCacheState.NoFlagData);
 
@@ -758,7 +758,7 @@ describe("ConfigCatClient", () => {
       const elapsedMilliseconds: number = getMonotonicTimeMs() - startTime;
 
       assert.isAtLeast(elapsedMilliseconds, (maxInitWaitTimeSeconds * 1000) - 25); // 25 ms for tolerance
-      assert.isAtMost(elapsedMilliseconds, (maxInitWaitTimeSeconds * 1000) + 100); // 100 ms for tolerance
+      assert.isAtMost(elapsedMilliseconds, (maxInitWaitTimeSeconds * 1000) + 125); // 125 ms for tolerance
 
       assert.equal(state, ClientCacheState.HasCachedFlagDataOnly);
 

--- a/test/ConfigCatConfigFetcherTests.ts
+++ b/test/ConfigCatConfigFetcherTests.ts
@@ -87,7 +87,7 @@ describe("ConfigCatConfigFetcherTests", () => {
     assert.strictEqual(configFetcherRequests.length, 1);
     assert.isUndefined(configFetcherRequests[0].lastETag);
 
-    // TODO: Change CORS settings so we can access the CF-RAY header? (https://stackoverflow.com/a/15043027)
+    // TODO: Remove this as soon as we update the CDN CORS settings (see also https://trello.com/c/RSGwVoqC)
     const clientVersion: string = (((client as ConfigCatClient)["options"]) as OptionsBase)["clientVersion"];
     if (clientVersion.includes("ConfigCat-UnifiedJS-Browser") || clientVersion.includes("ConfigCat-UnifiedJS-ChromiumExtension")) {
       return;

--- a/test/ConfigCatConfigFetcherTests.ts
+++ b/test/ConfigCatConfigFetcherTests.ts
@@ -1,0 +1,91 @@
+import { assert } from "chai";
+import { FakeConfigFetcherWithTwoKeys, FakeLogger } from "./helpers/fakes";
+import { platform } from "./helpers/platform";
+import { FetchRequest, FetchResponse, IConfigCatConfigFetcher } from "#lib";
+
+describe("ConfigCatConfigFetcherTests", () => {
+
+  it("Custom config fetcher - Success", async () => {
+    // Arrange
+
+    const configJson = FakeConfigFetcherWithTwoKeys.configJson;
+
+    const eTag = "\"abc\"";
+    const responseHeaders: [string, string][] = [
+      ["CF-RAY", "CF-12345"],
+      ["ETag", eTag],
+    ];
+
+    const configFetcherRequests: FetchRequest[] = [];
+    const configFetcher = new class implements IConfigCatConfigFetcher {
+      fetchAsync(request: FetchRequest) {
+        configFetcherRequests.push(request);
+        return Promise.resolve(new FetchResponse(200, "OK", responseHeaders, configJson));
+      }
+    }();
+
+    const client = platform().createClientWithManualPoll(
+      "test-67890123456789012/1234567890123456789012",
+      { configFetcher }
+    );
+
+    // Act
+
+    await client.forceRefreshAsync();
+    let value = await client.getValueAsync("debug", false);
+
+    assert.strictEqual(value, true);
+
+    assert.strictEqual(configFetcherRequests.length, 1);
+    assert.isUndefined(configFetcherRequests[0].lastETag);
+
+    await client.forceRefreshAsync();
+    value = await client.getValueAsync("debug", false);
+
+    // Assert
+
+    assert.strictEqual(value, true);
+
+    assert.strictEqual(configFetcherRequests.length, 2);
+    assert.strictEqual(configFetcherRequests[1].lastETag, eTag);
+  });
+
+  it("Custom config fetcher - Failure", async () => {
+    // Arrange
+
+    const fakeLogger = new FakeLogger();
+
+    const responseHeaders: [string, string][] = [
+      ["CF-RAY", "CF-12345"],
+    ];
+
+    const configFetcherRequests: FetchRequest[] = [];
+    const configFetcher = new class implements IConfigCatConfigFetcher {
+      fetchAsync(request: FetchRequest) {
+        configFetcherRequests.push(request);
+        return Promise.resolve(new FetchResponse(403, "Forbidden", responseHeaders));
+      }
+    }();
+
+    const client = platform().createClientWithManualPoll(
+      "test-67890123456789012/1234567890123456789012",
+      { configFetcher, logger: fakeLogger }
+    );
+
+    // Act
+
+    await client.forceRefreshAsync();
+    const value = await client.getValueAsync("debug", false);
+
+    // Assert
+
+    assert.strictEqual(value, false);
+
+    assert.strictEqual(configFetcherRequests.length, 1);
+    assert.isUndefined(configFetcherRequests[0].lastETag);
+
+    const errors = fakeLogger.events.filter(([, eventId]) => eventId === 1100);
+    assert.strictEqual(errors.length, 1);
+  });
+
+});

--- a/test/DefaultUserTests.ts
+++ b/test/DefaultUserTests.ts
@@ -10,7 +10,7 @@ describe("DefaultUser", () => {
     const redEyeColorUser = { identifier: "redIdentifier", custom: { "eyeColor": "red" } };
     const blueEyeColorUser = { identifier: "blueIdentifier", custom: { "eyeColor": "blue" } };
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithRules() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithRules() });
     const client: IConfigCatClient = createClientWithAutoPoll("APIKEY", configCatKernel, { logger: createConsoleLogger(LogLevel.Debug) });
 
     // Without passing the userobject, default values/variationids should be returned
@@ -91,7 +91,7 @@ describe("DefaultUser", () => {
     const redEyeColorUser = { identifier: "redIdentifier", custom: { "eyeColor": "red" } };
     const blueEyeColorUser = { identifier: "blueIdentifier", custom: { "eyeColor": "blue" } };
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcherWithRules() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcherWithRules() });
     const client: IConfigCatClient = createClientWithAutoPoll("APIKEY", configCatKernel, { logger: createConsoleLogger(LogLevel.Debug), defaultUser: redEyeColorUser });
 
     // Without passing the userobject, default user from the constructor should be returned

--- a/test/IndexTests.ts
+++ b/test/IndexTests.ts
@@ -8,7 +8,7 @@ describe("ConfigCatClient index (main)", () => {
 
   it("getClient ShouldCreateInstance - AutoPoll", () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const client: IConfigCatClient = configcatClient.getClient("SDKKEY-890123456789012/1234567890123456789012", PollingMode.AutoPoll, void 0, configCatKernel);
 
     try {
@@ -20,7 +20,7 @@ describe("ConfigCatClient index (main)", () => {
 
   it("getClient ShouldCreateInstance - LazyLoad", () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const client: IConfigCatClient = configcatClient.getClient("SDKKEY-890123456789012/1234567890123456789012", PollingMode.LazyLoad, void 0, configCatKernel);
 
     try {
@@ -32,7 +32,7 @@ describe("ConfigCatClient index (main)", () => {
 
   it("getClient ShouldCreateInstance - ManualPoll", () => {
 
-    const configCatKernel = createKernel({ configFetcher: new FakeConfigFetcher() });
+    const configCatKernel = createKernel({ configFetcherFactory: () => new FakeConfigFetcher() });
     const client: IConfigCatClient = configcatClient.getClient("SDKKEY-890123456789012/1234567890123456789012", PollingMode.ManualPoll, void 0, configCatKernel);
 
     try {

--- a/test/IntegrationTests.ts
+++ b/test/IntegrationTests.ts
@@ -295,7 +295,7 @@ describe("Integration tests - Other cases", () => {
 
     const client: IConfigCatClient = platform().getClient("configcat-sdk-1/~~~~~~~~~~~~~~~~~~~~~~/~~~~~~~~~~~~~~~~~~~~~~", PollingMode.ManualPoll, { logger: fakeLogger });
 
-    // TODO: Change CORS settings so we can access the CF-RAY header? (https://stackoverflow.com/a/15043027)
+    // TODO: Remove this as soon as we update the CDN CORS settings (see also https://trello.com/c/RSGwVoqC)
     const clientVersion: string = (((client as ConfigCatClient)["options"]) as OptionsBase)["clientVersion"];
     if (clientVersion.includes("ConfigCat-UnifiedJS-Browser") || clientVersion.includes("ConfigCat-UnifiedJS-ChromiumExtension")) {
       this.skip();

--- a/test/IntegrationTests.ts
+++ b/test/IntegrationTests.ts
@@ -1,7 +1,9 @@
-import { assert } from "chai";
+import { assert, expect } from "chai";
+import { FakeLogger } from "./helpers/fakes";
 import { platform } from "./helpers/platform";
-import { IConfigCatClient, IEvaluationDetails, IOptions, LogLevel, OverrideBehaviour, PollingMode, SettingKeyValue, User } from "#lib";
-import { createConsoleLogger, createFlagOverridesFromMap } from "#lib/index.pubternals";
+import { FormattableLogMessage, IConfigCatClient, IEvaluationDetails, IOptions, LogLevel, OverrideBehaviour, PollingMode, SettingKeyValue, User } from "#lib";
+import { ConfigCatClient } from "#lib/ConfigCatClient";
+import { createConsoleLogger, createFlagOverridesFromMap, OptionsBase } from "#lib/index.pubternals";
 
 const sdkKey = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";
 
@@ -286,6 +288,37 @@ describe("Integration tests - Other cases", () => {
       actual = await clientOverride.getValueAsync("stringDefaultCat", defaultValue);
       assert.strictEqual(actual, "ANOTHER_CAT");
     } finally { clientOverride.dispose(); }
+  });
+
+  it("Should include ray ID in log messages when http response is not successful", async function() {
+    const fakeLogger = new FakeLogger();
+
+    const client: IConfigCatClient = platform().getClient("configcat-sdk-1/~~~~~~~~~~~~~~~~~~~~~~/~~~~~~~~~~~~~~~~~~~~~~", PollingMode.ManualPoll, { logger: fakeLogger });
+
+    // TODO: Change CORS settings so we can access the CF-RAY header? (https://stackoverflow.com/a/15043027)
+    const clientVersion: string = (((client as ConfigCatClient)["options"]) as OptionsBase)["clientVersion"];
+    if (clientVersion.includes("ConfigCat-UnifiedJS-Browser") || clientVersion.includes("ConfigCat-UnifiedJS-ChromiumExtension")) {
+      this.skip();
+    }
+
+    await client.forceRefreshAsync();
+
+    const errors = fakeLogger.events.filter(([, eventId]) => eventId === 1100);
+    assert.strictEqual(errors.length, 1);
+
+    const [[, , error]] = errors;
+    assert.instanceOf(error, FormattableLogMessage);
+
+    assert.strictEqual(error.argNames.length, 1);
+    assert.strictEqual(error.argNames[0], "RAY_ID");
+
+    assert.strictEqual(error.argValues.length, 1);
+    const [rayId] = error.argValues;
+    assert.isString(rayId);
+
+    expect(error.toString()).to.contain(rayId);
+
+    client.dispose();
   });
 
 });

--- a/test/OverrideTests.ts
+++ b/test/OverrideTests.ts
@@ -11,7 +11,7 @@ import { EvaluationError, EvaluationErrorCode, isAllowedValue } from "#lib/Rollo
 describe("Local Overrides", () => {
   it("Values from map - LocalOnly", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
     });
 
     const overrideMap = {
@@ -50,7 +50,7 @@ describe("Local Overrides", () => {
 
   it("Values from map - LocalOnly - watch changes - async", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
     });
 
     const overrideMap = {
@@ -89,7 +89,7 @@ describe("Local Overrides", () => {
 
   it("Values from map - LocalOnly - watch changes - sync", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
     });
 
     const overrideMap = {
@@ -130,7 +130,7 @@ describe("Local Overrides", () => {
 
   it("Values from map - LocalOverRemote", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
     });
     const options: AutoPollOptions = createAutoPollOptions("localhost", {
       flagOverrides: {
@@ -151,7 +151,7 @@ describe("Local Overrides", () => {
 
   it("Values from map - RemoteOverLocal", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
     });
     const options: AutoPollOptions = createAutoPollOptions("localhost", {
       flagOverrides: {
@@ -172,7 +172,7 @@ describe("Local Overrides", () => {
 
   it("Values from map - RemoteOverLocal - failing remote", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase(null),
+      configFetcherFactory: () => new FakeConfigFetcherBase(null),
     });
     const options: AutoPollOptions = createAutoPollOptions("localhost", {
       flagOverrides: {
@@ -200,7 +200,7 @@ describe("Local Overrides", () => {
     dataSource["double_setting"] = 3.14;
     dataSource["string-setting"] = "test";
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
     });
     const options: AutoPollOptions = createAutoPollOptions("localhost", {
       flagOverrides: {
@@ -222,7 +222,7 @@ describe("Local Overrides", () => {
 
   it("Values from query string - changes not watched", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
     });
 
     let currentQueryString = "?cc-stringDefaultCat=OVERRIDE_CAT&stringDefaultDog=OVERRIDE_DOG";
@@ -246,7 +246,7 @@ describe("Local Overrides", () => {
 
   it("Values from query string - changes watched", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
     });
 
     let currentQueryString = "?cc-stringDefaultCat=OVERRIDE_CAT&stringDefaultDog=OVERRIDE_DOG";
@@ -270,7 +270,7 @@ describe("Local Overrides", () => {
 
   it("Values from query string - parsed query string", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
     });
 
     let currentQueryString: { [key: string]: string } = {
@@ -299,7 +299,7 @@ describe("Local Overrides", () => {
 
   it("Values from query string - respects custom parameter name prefix", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"numberDefaultZero":{"t":2,"v":{"i":42}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"numberDefaultZero":{"t":2,"v":{"i":42}}}}'),
     });
 
     const currentQueryString = "?numberDefaultZero=43&cc-numberDefaultZero=44";
@@ -318,7 +318,7 @@ describe("Local Overrides", () => {
 
   it("Values from query string - respects force string value suffix", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}}}}'),
     });
 
     const currentQueryString = "?cc-stringDefaultCat;str=TRUE&cc-boolDefaultFalse=TRUE";
@@ -337,7 +337,7 @@ describe("Local Overrides", () => {
 
   it("Values from query string - handles query string edge cases", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}}}}'),
     });
 
     const currentQueryString = "?&some&=garbage&&cc-stringDefaultCat=OVERRIDE_CAT&=cc-stringDefaultCat&cc-stringDefaultCat";
@@ -356,7 +356,7 @@ describe("Local Overrides", () => {
 
   it("LocalOnly - forceRefreshAsync() should return failure", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"fakeKey":{"t":0,"v":{"b":false}}}}'),
     });
     const options: ManualPollOptions = createManualPollOptions("localhost", {
       flagOverrides: {
@@ -408,7 +408,7 @@ describe("Local Overrides", () => {
       const map = { [key]: overrideValue as NonNullable<SettingValue> };
 
       const configCatKernel = createKernel({
-        configFetcher: new FakeConfigFetcherWithNullNewConfig(),
+        configFetcherFactory: () => new FakeConfigFetcherWithNullNewConfig(),
       });
 
       const options: ManualPollOptions = createManualPollOptions("localhost", {

--- a/test/VariationIdTests.ts
+++ b/test/VariationIdTests.ts
@@ -6,7 +6,7 @@ import { AutoPollOptions } from "#lib/ConfigCatClientOptions";
 describe("ConfigCatClient", () => {
   it("getKeyAndValueAsync() works with default", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherWithTwoKeysAndRules(),
+      configFetcherFactory: () => new FakeConfigFetcherWithTwoKeysAndRules(),
     });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
@@ -20,7 +20,7 @@ describe("ConfigCatClient", () => {
 
   it("getKeyAndValueAsync() works with rollout rules", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherWithTwoKeysAndRules(),
+      configFetcherFactory: () => new FakeConfigFetcherWithTwoKeysAndRules(),
     });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
@@ -34,7 +34,7 @@ describe("ConfigCatClient", () => {
 
   it("getKeyAndValueAsync() works with percentage options", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherWithTwoKeysAndRules(),
+      configFetcherFactory: () => new FakeConfigFetcherWithTwoKeysAndRules(),
     });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
@@ -48,7 +48,7 @@ describe("ConfigCatClient", () => {
 
   it("getKeyAndValueAsync() works with percentage options within targeting rule", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherWithPercentageOptionsWithinTargetingRule(),
+      configFetcherFactory: () => new FakeConfigFetcherWithPercentageOptionsWithinTargetingRule(),
     });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
@@ -62,7 +62,7 @@ describe("ConfigCatClient", () => {
 
   it("getKeyAndValueAsync() with null config", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherWithNullNewConfig(),
+      configFetcherFactory: () => new FakeConfigFetcherWithNullNewConfig(),
     });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null, maxInitWaitTimeSeconds: 0 }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
@@ -75,7 +75,7 @@ describe("ConfigCatClient", () => {
 
   it("getKeyAndValueAsync() with non-existing id", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherWithTwoKeysAndRules(),
+      configFetcherFactory: () => new FakeConfigFetcherWithTwoKeysAndRules(),
     });
     const options: AutoPollOptions = createAutoPollOptions("APIKEY", { logger: null }, configCatKernel);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);

--- a/test/browser/index.ts
+++ b/test/browser/index.ts
@@ -35,7 +35,7 @@ class BrowserPlatform extends PlatformAbstractions<IJSAutoPollOptions, IJSManual
     });
   }
 
-  createConfigFetcher(options: OptionsBase, platformOptions?: IJSOptions) { return XmlHttpRequestConfigFetcher.getFactory()(options); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IJSOptions) { return XmlHttpRequestConfigFetcher["getFactory"]()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IJSOptions) {
     const kernel: IConfigCatKernel = {
@@ -45,7 +45,7 @@ class BrowserPlatform extends PlatformAbstractions<IJSAutoPollOptions, IJSManual
       configFetcherFactory: o => this.createConfigFetcher(o, options),
     };
     setupKernel ??= kernel => {
-      kernel.defaultCacheFactory = LocalStorageConfigCache.tryGetFactory();
+      kernel.defaultCacheFactory = LocalStorageConfigCache["tryGetFactory"]();
       return kernel;
     };
     return setupKernel(kernel);

--- a/test/browser/index.ts
+++ b/test/browser/index.ts
@@ -4,7 +4,7 @@ import { getClient } from "#lib/browser";
 import { LocalStorageConfigCache } from "#lib/browser/LocalStorageConfigCache";
 import { XmlHttpRequestConfigFetcher } from "#lib/browser/XmlHttpRequestConfigFetcher";
 import { DefaultEventEmitter } from "#lib/DefaultEventEmitter";
-import type { IConfigCatKernel } from "#lib/index.pubternals";
+import type { IConfigCatKernel, OptionsBase } from "#lib/index.pubternals";
 import sdkVersion from "#lib/Version";
 
 const sdkType = "ConfigCat-UnifiedJS-Browser";
@@ -35,10 +35,15 @@ class BrowserPlatform extends PlatformAbstractions<IJSAutoPollOptions, IJSManual
     });
   }
 
-  createConfigFetcher(options?: IJSOptions) { return new XmlHttpRequestConfigFetcher(); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IJSOptions) { return XmlHttpRequestConfigFetcher.getFactory()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IJSOptions) {
-    const kernel: IConfigCatKernel = { configFetcher: this.createConfigFetcher(options), sdkType, sdkVersion, eventEmitterFactory: () => new DefaultEventEmitter() };
+    const kernel: IConfigCatKernel = {
+      sdkType,
+      sdkVersion,
+      eventEmitterFactory: () => new DefaultEventEmitter(),
+      configFetcherFactory: o => this.createConfigFetcher(o, options),
+    };
     setupKernel ??= kernel => {
       kernel.defaultCacheFactory = LocalStorageConfigCache.tryGetFactory();
       return kernel;

--- a/test/bun/index.ts
+++ b/test/bun/index.ts
@@ -8,7 +8,7 @@ import { normalizePathSeparator } from "../helpers/utils";
 import { isTestSpec } from "../index";
 import type { IBunAutoPollOptions, IBunLazyLoadingOptions, IBunManualPollOptions } from "#lib/bun";
 import { getClient } from "#lib/bun";
-import type { IConfigCatKernel } from "#lib/index.pubternals";
+import type { IConfigCatKernel, OptionsBase } from "#lib/index.pubternals";
 import { NodeHttpConfigFetcher } from "#lib/node/NodeHttpConfigFetcher";
 import sdkVersion from "#lib/Version";
 
@@ -29,10 +29,15 @@ class BunPlatform extends PlatformAbstractions<IBunAutoPollOptions, IBunManualPo
 
   readFileUtf8(path: string) { return fs.readFileSync(path, "utf8"); }
 
-  createConfigFetcher(options?: IBunOptions) { return new NodeHttpConfigFetcher(options); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IBunOptions) { return NodeHttpConfigFetcher.getFactory()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IBunOptions) {
-    const kernel: IConfigCatKernel = { configFetcher: this.createConfigFetcher(options), sdkType, sdkVersion, eventEmitterFactory: () => new EventEmitter() };
+    const kernel: IConfigCatKernel = {
+      sdkType,
+      sdkVersion,
+      eventEmitterFactory: () => new EventEmitter(),
+      configFetcherFactory: o => this.createConfigFetcher(o, options),
+    };
     return (setupKernel ?? (k => k))(kernel);
   }
 

--- a/test/bun/index.ts
+++ b/test/bun/index.ts
@@ -29,7 +29,7 @@ class BunPlatform extends PlatformAbstractions<IBunAutoPollOptions, IBunManualPo
 
   readFileUtf8(path: string) { return fs.readFileSync(path, "utf8"); }
 
-  createConfigFetcher(options: OptionsBase, platformOptions?: IBunOptions) { return NodeHttpConfigFetcher.getFactory()(options); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IBunOptions) { return NodeHttpConfigFetcher["getFactory"]()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IBunOptions) {
     const kernel: IConfigCatKernel = {

--- a/test/chromium-extension/index.ts
+++ b/test/chromium-extension/index.ts
@@ -3,7 +3,7 @@ import type { IJSAutoPollOptions, IJSLazyLoadingOptions, IJSManualPollOptions } 
 import { getClient } from "#lib/chromium-extension";
 import { ChromeLocalStorageConfigCache } from "#lib/chromium-extension/ChromeLocalStorageConfigCache";
 import { DefaultEventEmitter } from "#lib/DefaultEventEmitter";
-import type { IConfigCatKernel } from "#lib/index.pubternals";
+import type { IConfigCatKernel, OptionsBase } from "#lib/index.pubternals";
 import { FetchApiConfigFetcher } from "#lib/shared/FetchApiConfigFetcher";
 import sdkVersion from "#lib/Version";
 
@@ -23,10 +23,15 @@ class ChromiumExtensionPlatform extends PlatformAbstractions<IJSAutoPollOptions,
     }
   }
 
-  createConfigFetcher(options?: IJSOptions) { return new FetchApiConfigFetcher(); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IJSOptions) { return FetchApiConfigFetcher.getFactory()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IJSOptions) {
-    const kernel: IConfigCatKernel = { configFetcher: this.createConfigFetcher(options), sdkType, sdkVersion, eventEmitterFactory: () => new DefaultEventEmitter() };
+    const kernel: IConfigCatKernel = {
+      sdkType,
+      sdkVersion,
+      eventEmitterFactory: () => new DefaultEventEmitter(),
+      configFetcherFactory: o => this.createConfigFetcher(o, options),
+    };
     setupKernel ??= kernel => {
       kernel.defaultCacheFactory = ChromeLocalStorageConfigCache.tryGetFactory();
       return kernel;

--- a/test/chromium-extension/index.ts
+++ b/test/chromium-extension/index.ts
@@ -23,7 +23,7 @@ class ChromiumExtensionPlatform extends PlatformAbstractions<IJSAutoPollOptions,
     }
   }
 
-  createConfigFetcher(options: OptionsBase, platformOptions?: IJSOptions) { return FetchApiConfigFetcher.getFactory()(options); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IJSOptions) { return FetchApiConfigFetcher["getFactory"]()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IJSOptions) {
     const kernel: IConfigCatKernel = {
@@ -33,7 +33,7 @@ class ChromiumExtensionPlatform extends PlatformAbstractions<IJSAutoPollOptions,
       configFetcherFactory: o => this.createConfigFetcher(o, options),
     };
     setupKernel ??= kernel => {
-      kernel.defaultCacheFactory = ChromeLocalStorageConfigCache.tryGetFactory();
+      kernel.defaultCacheFactory = ChromeLocalStorageConfigCache["tryGetFactory"]();
       return kernel;
     };
     return setupKernel(kernel);

--- a/test/cloudflare-worker/OverrideTests.ts
+++ b/test/cloudflare-worker/OverrideTests.ts
@@ -12,7 +12,7 @@ declare const Request: typeof cloudflare.Request;
 describe("Flag Overrides (Cloudflare Workers)", () => {
   it("Values from query string - using request", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
     });
 
     const currentQueryString = "?cc-stringDefaultCat=OVERRIDE_CAT&stringDefaultDog=OVERRIDE_DOG";
@@ -31,7 +31,7 @@ describe("Flag Overrides (Cloudflare Workers)", () => {
 
   it("Values from query string - using custom query string provider", async () => {
     const configCatKernel = createKernel({
-      configFetcher: new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
+      configFetcherFactory: () => new FakeConfigFetcherBase('{"f":{"stringDefaultCat":{"t":1,"v":{"s":"CAT"}},"stringDefaultDog":{"t":1,"v":{"s":"DOG"}}}}'),
     });
 
     let currentQueryString = "?cc-stringDefaultCat=OVERRIDE_CAT&stringDefaultDog=OVERRIDE_DOG";

--- a/test/cloudflare-worker/index.ts
+++ b/test/cloudflare-worker/index.ts
@@ -51,7 +51,7 @@ class CloudflareWorkerPlatform extends PlatformAbstractions<IJSAutoPollOptions, 
     }
   }
 
-  createConfigFetcher(options: OptionsBase, platformOptions?: IJSOptions) { return FetchApiConfigFetcher.getFactory()(options); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IJSOptions) { return FetchApiConfigFetcher["getFactory"]()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IJSOptions) {
     const kernel: IConfigCatKernel = {
@@ -61,7 +61,7 @@ class CloudflareWorkerPlatform extends PlatformAbstractions<IJSAutoPollOptions, 
       configFetcherFactory: o => this.createConfigFetcher(o, options),
     };
     setupKernel ??= kernel => {
-      kernel.defaultCacheFactory = CloudflareConfigCache.tryGetFactory();
+      kernel.defaultCacheFactory = CloudflareConfigCache["tryGetFactory"]();
       return kernel;
     };
     return setupKernel(kernel);

--- a/test/cloudflare-worker/index.ts
+++ b/test/cloudflare-worker/index.ts
@@ -51,10 +51,15 @@ class CloudflareWorkerPlatform extends PlatformAbstractions<IJSAutoPollOptions, 
     }
   }
 
-  createConfigFetcher(options?: IJSOptions) { return new FetchApiConfigFetcher(); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IJSOptions) { return FetchApiConfigFetcher.getFactory()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IJSOptions) {
-    const kernel: IConfigCatKernel = { configFetcher: this.createConfigFetcher(options), sdkType, sdkVersion, eventEmitterFactory: () => new DefaultEventEmitter() };
+    const kernel: IConfigCatKernel = {
+      sdkType,
+      sdkVersion,
+      eventEmitterFactory: () => new DefaultEventEmitter(),
+      configFetcherFactory: o => this.createConfigFetcher(o, options),
+    };
     setupKernel ??= kernel => {
       kernel.defaultCacheFactory = CloudflareConfigCache.tryGetFactory();
       return kernel;

--- a/test/deno/index.ts
+++ b/test/deno/index.ts
@@ -7,7 +7,6 @@ import { DefaultEventEmitter } from "#lib/DefaultEventEmitter";
 import type { IDenoAutoPollOptions, IDenoLazyLoadingOptions, IDenoManualPollOptions } from "#lib/deno";
 import { DenoHttpConfigFetcher, getClient } from "#lib/deno";
 import type { IConfigCatKernel, OptionsBase } from "#lib/index.pubternals";
-import { FetchApiConfigFetcher } from "#lib/shared/FetchApiConfigFetcher";
 import sdkVersion from "#lib/Version";
 
 const sdkType = "ConfigCat-UnifiedJS-Deno";

--- a/test/deno/index.ts
+++ b/test/deno/index.ts
@@ -5,7 +5,7 @@ import { initPlatform, PlatformAbstractions } from "../helpers/platform";
 import { isTestSpec } from "../index";
 import { DefaultEventEmitter } from "#lib/DefaultEventEmitter";
 import type { IDenoAutoPollOptions, IDenoLazyLoadingOptions, IDenoManualPollOptions } from "#lib/deno";
-import { getClient } from "#lib/deno";
+import { DenoHttpConfigFetcher, getClient } from "#lib/deno";
 import type { IConfigCatKernel, OptionsBase } from "#lib/index.pubternals";
 import { FetchApiConfigFetcher } from "#lib/shared/FetchApiConfigFetcher";
 import sdkVersion from "#lib/Version";
@@ -58,7 +58,7 @@ class DenoPlatform extends PlatformAbstractions<IDenoAutoPollOptions, IDenoManua
 
   readFileUtf8(path: string) { return Deno.readTextFileSync(path); }
 
-  createConfigFetcher(options: OptionsBase, platformOptions?: IDenoOptions) { return FetchApiConfigFetcher["getFactory"]()(options); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IDenoOptions) { return DenoHttpConfigFetcher["getFactory"]()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IDenoOptions) {
     const kernel: IConfigCatKernel = {

--- a/test/deno/index.ts
+++ b/test/deno/index.ts
@@ -3,10 +3,10 @@ import * as path from "https://deno.land/std@0.224.0/path/mod.ts";
 import "npm:mocha/browser-entry.js";
 import { initPlatform, PlatformAbstractions } from "../helpers/platform";
 import { isTestSpec } from "../index";
-import { IConfigCatKernel } from "#lib/ConfigCatClient";
 import { DefaultEventEmitter } from "#lib/DefaultEventEmitter";
 import type { IDenoAutoPollOptions, IDenoLazyLoadingOptions, IDenoManualPollOptions } from "#lib/deno";
 import { getClient } from "#lib/deno";
+import type { IConfigCatKernel, OptionsBase } from "#lib/index.pubternals";
 import { FetchApiConfigFetcher } from "#lib/shared/FetchApiConfigFetcher";
 import sdkVersion from "#lib/Version";
 
@@ -58,10 +58,15 @@ class DenoPlatform extends PlatformAbstractions<IDenoAutoPollOptions, IDenoManua
 
   readFileUtf8(path: string) { return Deno.readTextFileSync(path); }
 
-  createConfigFetcher(options?: IDenoOptions) { return new FetchApiConfigFetcher(); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IDenoOptions) { return FetchApiConfigFetcher.getFactory()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IDenoOptions) {
-    const kernel: IConfigCatKernel = { configFetcher: this.createConfigFetcher(options), sdkType, sdkVersion, eventEmitterFactory: () => new DefaultEventEmitter() };
+    const kernel: IConfigCatKernel = {
+      sdkType,
+      sdkVersion,
+      eventEmitterFactory: () => new DefaultEventEmitter(),
+      configFetcherFactory: o => this.createConfigFetcher(o, options),
+    };
     return (setupKernel ?? (k => k))(kernel);
   }
 

--- a/test/deno/index.ts
+++ b/test/deno/index.ts
@@ -58,7 +58,7 @@ class DenoPlatform extends PlatformAbstractions<IDenoAutoPollOptions, IDenoManua
 
   readFileUtf8(path: string) { return Deno.readTextFileSync(path); }
 
-  createConfigFetcher(options: OptionsBase, platformOptions?: IDenoOptions) { return FetchApiConfigFetcher.getFactory()(options); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: IDenoOptions) { return FetchApiConfigFetcher["getFactory"]()(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: IDenoOptions) {
     const kernel: IConfigCatKernel = {

--- a/test/helpers/ConfigLocation.ts
+++ b/test/helpers/ConfigLocation.ts
@@ -55,8 +55,7 @@ export class CdnConfigLocation extends ConfigLocation {
   }
 
   async fetchConfigAsync(): Promise<Config> {
-    const configFetcher = platform().createConfigFetcher();
-    const configService = new ManualPollConfigService(configFetcher, this.options);
+    const configService = new ManualPollConfigService(this.options);
 
     const [fetchResult, projectConfig] = await configService.refreshConfigAsync();
     if (!fetchResult.isSuccess) {

--- a/test/helpers/platform.ts
+++ b/test/helpers/platform.ts
@@ -1,7 +1,7 @@
-import type { IAutoPollOptions, IConfigCatClient, ILazyLoadingOptions, IManualPollOptions, IOptions, PollingMode } from "#lib";
+import type { IAutoPollOptions, IConfigCatClient, IConfigCatConfigFetcher as IConfigFetcher, ILazyLoadingOptions, IManualPollOptions, IOptions, PollingMode } from "#lib";
 import { ConfigCatClient } from "#lib/ConfigCatClient";
 import { AutoPollOptions, LazyLoadOptions, ManualPollOptions } from "#lib/ConfigCatClientOptions";
-import type { IConfigCatKernel, IConfigFetcher, OptionsBase } from "#lib/index.pubternals";
+import type { IConfigCatKernel, OptionsBase } from "#lib/index.pubternals";
 
 type OptionsForPollingMode<
   TMode extends PollingMode | unknown,
@@ -30,28 +30,28 @@ export abstract class PlatformAbstractions<
 
   abstract readFileUtf8(path: string): string | Promise<string>;
 
-  abstract createConfigFetcher(options?: TAutoPollOptions | TManualPollOptions | TLazyLoadingOptions): IConfigFetcher;
+  abstract createConfigFetcher(options: OptionsBase, platformOptions?: TAutoPollOptions | TManualPollOptions | TLazyLoadingOptions): IConfigFetcher;
 
   abstract createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: TAutoPollOptions | TManualPollOptions | TLazyLoadingOptions): IConfigCatKernel;
 
   createAutoPollOptions(sdkKey: string, options?: TAutoPollOptions, kernel?: IConfigCatKernel): AugmentedOptions<AutoPollOptions> {
     kernel ??= this.createKernel(void 0, options);
     return this.augmentOptions(
-      new AutoPollOptions(sdkKey, kernel.sdkType, kernel.sdkVersion, this.adjustOptions(options), kernel.defaultCacheFactory, kernel.eventEmitterFactory)
+      new AutoPollOptions(sdkKey, kernel, this.adjustOptions(options))
     );
   }
 
   createManualPollOptions(sdkKey: string, options?: TManualPollOptions, kernel?: IConfigCatKernel): AugmentedOptions<ManualPollOptions> {
     kernel ??= this.createKernel(void 0, options);
     return this.augmentOptions(
-      new ManualPollOptions(sdkKey, kernel.sdkType, kernel.sdkVersion, this.adjustOptions(options), kernel.defaultCacheFactory, kernel.eventEmitterFactory)
+      new ManualPollOptions(sdkKey, kernel, this.adjustOptions(options))
     );
   }
 
   createLazyLoadOptions(sdkKey: string, options?: TLazyLoadingOptions, kernel?: IConfigCatKernel): AugmentedOptions<LazyLoadOptions> {
     kernel ??= this.createKernel(void 0, options);
     return this.augmentOptions(
-      new LazyLoadOptions(sdkKey, kernel.sdkType, kernel.sdkVersion, this.adjustOptions(options), kernel.defaultCacheFactory, kernel.eventEmitterFactory)
+      new LazyLoadOptions(sdkKey, kernel, this.adjustOptions(options))
     );
   }
 

--- a/test/node/index.ts
+++ b/test/node/index.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 import { initPlatform, PlatformAbstractions } from "../helpers/platform";
 import { normalizePathSeparator } from "../helpers/utils";
 import { isTestSpec } from "../index";
-import type { IConfigCatKernel } from "#lib/index.pubternals";
+import type { IConfigCatKernel, OptionsBase } from "#lib/index.pubternals";
 import type { INodeAutoPollOptions, INodeLazyLoadingOptions, INodeManualPollOptions } from "#lib/node";
 import { getClient } from "#lib/node";
 import { NodeHttpConfigFetcher } from "#lib/node/NodeHttpConfigFetcher";
@@ -30,10 +30,15 @@ class NodePlatform extends PlatformAbstractions<INodeAutoPollOptions, INodeManua
 
   readFileUtf8(path: string) { return fs.readFileSync(path, "utf8"); }
 
-  createConfigFetcher(options?: INodeOptions) { return new NodeHttpConfigFetcher(options); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: INodeOptions) { return NodeHttpConfigFetcher.getFactory(platformOptions)(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: INodeOptions) {
-    const kernel: IConfigCatKernel = { configFetcher: this.createConfigFetcher(options), sdkType, sdkVersion, eventEmitterFactory: () => new EventEmitter() };
+    const kernel: IConfigCatKernel = {
+      sdkType,
+      sdkVersion,
+      eventEmitterFactory: () => new EventEmitter(),
+      configFetcherFactory: o => this.createConfigFetcher(o, options),
+    };
     return (setupKernel ?? (k => k))(kernel);
   }
 

--- a/test/node/index.ts
+++ b/test/node/index.ts
@@ -30,7 +30,7 @@ class NodePlatform extends PlatformAbstractions<INodeAutoPollOptions, INodeManua
 
   readFileUtf8(path: string) { return fs.readFileSync(path, "utf8"); }
 
-  createConfigFetcher(options: OptionsBase, platformOptions?: INodeOptions) { return NodeHttpConfigFetcher.getFactory(platformOptions)(options); }
+  createConfigFetcher(options: OptionsBase, platformOptions?: INodeOptions) { return NodeHttpConfigFetcher["getFactory"](platformOptions)(options); }
 
   createKernel(setupKernel?: (kernel: IConfigCatKernel) => IConfigCatKernel, options?: INodeOptions) {
     const kernel: IConfigCatKernel = {

--- a/tsconfig.mocha.node.json
+++ b/tsconfig.mocha.node.json
@@ -6,7 +6,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "paths": {
-      "#lib/node": ["./lib/cjs/node/index.root"],
+      "#lib/node": ["./lib/cjs/node/index"],
       "#lib": ["./lib/cjs/index"],
       "#lib/*": ["./lib/cjs/*"]
     },


### PR DESCRIPTION
### Describe the purpose of your pull request
Adds a new option named `configFetcher`, which allows consumers to choose the config fetcher implementation to use or to provide their own implementation (useful for testing and also allows customizing the request headers).

Plus, makes sure that Cloudflare Ray ID is included into log messages when the HTTP response is not successful. (We'll need some further CORS configuration to make this work in browser targets).

Also,
* corrects the API surface area of the main entry point,
* fixes a few minor bugs.

### Related issues (only if applicable)
https://trello.com/c/Fdzvind3
https://trello.com/c/iCm8OlJv
https://trello.com/c/KBkmlPk2

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
