### PR TITLE
Retry failed HTTP requests

### DIFF
--- a/.github/workflows/js-sdk-ci.yml
+++ b/.github/workflows/js-sdk-ci.yml
@@ -14,7 +14,14 @@ on:
 jobs:
   check-ts-compat:
     runs-on: ubuntu-latest
-    name: TypeScript v4.0.2 compatibility check
+    strategy:
+      matrix:
+        ts-version: [
+          {display: "v4.0.2", tag: "", tsc_args: ""},
+          {display: "v5.x", tag: "<6.0.0", tsc_args: ""},
+          {display: "v6.x", tag: "<7.0.0", tsc_args: "--ignoreDeprecations 6.0"},
+        ]
+    name: TypeScript ${{ matrix.ts-version.display }} compatibility check
     steps:
       - uses: actions/checkout@v6
 
@@ -25,8 +32,14 @@ jobs:
       - name: Install dependencies & build
         run: npm install
 
+      - name: Set TypeScript version
+        if: matrix.ts-version.tag != ''
+        working-directory: ./extra-checks/ts-compat-check
+        run: npm install typescript@"${{ matrix.ts-version.tag }}"
+
       - name: Run check
-        run: npm run check:ts-compat
+        working-directory: ./extra-checks/ts-compat-check
+        run: npm run check -- ${{ matrix.ts-version.tsc_args }}
 
   test-browser-chrome:
     # Runner image version is temporarily pinned to `ubuntu-22.04`.

--- a/karma.chromium-extension.conf.js
+++ b/karma.chromium-extension.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
     },
 
     reporters: [
-      "progress",
+      "spec",
       ...(enableCoverage ? ["coverage-istanbul"] : []),
     ],
 

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -1,4 +1,5 @@
 import type { AutoPollOptions } from "./ConfigCatClientOptions";
+import { logMethodDebug } from "./ConfigCatLogger";
 import type { FetchResult } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
@@ -75,32 +76,34 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
   }
 
   async getConfigAsync(): Promise<ProjectConfig> {
-    this.options.logger.debug("AutoPollConfigService.getConfigAsync() called.");
+    const methodName = "AutoPollConfigService.getConfigAsync";
+    const debugLogger = this.options.logger.ifDebug;
+    logMethodDebug(debugLogger, methodName);
 
     let cachedConfig = await this.syncUpWithCache();
 
     if (!cachedConfig.isExpired(this.pollIntervalMs)) {
       this.signalInitialization();
     } else if (!this.isOffline && !this.initialized) {
-      this.options.logger.debug("AutoPollConfigService.getConfigAsync() - cache is empty or expired, waiting for initialization.");
+      logMethodDebug(debugLogger, methodName, "cache is empty or expired, waiting for initialization.");
       await this.initializationPromise;
       cachedConfig = this.options.cache.getInMemory();
     } else {
-      this.options.logger.debug("AutoPollConfigService.getConfigAsync() - cache is empty or expired.");
+      logMethodDebug(debugLogger, methodName, "cache is empty or expired.");
       return cachedConfig;
     }
 
-    this.options.logger.debug("AutoPollConfigService.getConfigAsync() - returning value from cache.");
+    logMethodDebug(debugLogger, methodName, "returning value from cache.");
     return cachedConfig;
   }
 
   override refreshConfigAsync(): Promise<[RefreshResult, ProjectConfig]> {
-    this.options.logger.debug("AutoPollConfigService.refreshConfigAsync() called.");
+    logMethodDebug(this.options.logger, "AutoPollConfigService.refreshConfigAsync");
     return super.refreshConfigAsync();
   }
 
   override dispose(): void {
-    this.options.logger.debug("AutoPollConfigService.dispose() called.");
+    logMethodDebug(this.options.logger, "AutoPollConfigService.dispose");
     super.dispose();
     if (!this.stopToken.aborted) {
       this.stopRefreshWorker();
@@ -121,7 +124,7 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
   }
 
   private async startRefreshWorker(initialCacheSyncUp: ProjectConfig | Promise<ProjectConfig> | null, stopToken: AbortToken) {
-    this.options.logger.debug("AutoPollConfigService.startRefreshWorker() called.");
+    logMethodDebug(this.options.logger, "AutoPollConfigService.startRefreshWorker");
 
     while (!stopToken.aborted) {
       try {
@@ -145,12 +148,12 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
   }
 
   private stopRefreshWorker() {
-    this.options.logger.debug("AutoPollConfigService.stopRefreshWorker() called.");
+    logMethodDebug(this.options.logger, "AutoPollConfigService.stopRefreshWorker");
     this.stopToken.abort();
   }
 
   private async refreshWorkerLogic(initialCacheSyncUp: ProjectConfig | Promise<ProjectConfig> | null) {
-    this.options.logger.debug("AutoPollConfigService.refreshWorkerLogic() called.");
+    logMethodDebug(this.options.logger, "AutoPollConfigService.refreshWorkerLogic");
 
     const latestConfig = await (initialCacheSyncUp ?? this.syncUpWithCache());
     if (latestConfig.isExpired(this.pollExpirationMs)) {

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -135,9 +135,9 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
           this.options.logger.autoPollConfigServiceErrorDuringPolling(err);
         }
 
-        const realNextTimeMs = scheduledNextTimeMs - getMonotonicTimeMs();
-        if (realNextTimeMs > 0) {
-          await delay(realNextTimeMs, stopToken);
+        const timeToWaitMs = scheduledNextTimeMs - getMonotonicTimeMs();
+        if (timeToWaitMs > 0) {
+          await delay(timeToWaitMs, stopToken);
         }
       } catch (err) {
         this.options.logger.autoPollConfigServiceErrorDuringPolling(err);

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -1,6 +1,7 @@
 import type { AutoPollOptions } from "./ConfigCatClientOptions";
 import { logMethodDebug } from "./ConfigCatLogger";
 import type { FetchResult } from "./ConfigFetcher";
+import { FetchError } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
@@ -132,6 +133,10 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
         try {
           await this.refreshWorkerLogic(initialCacheSyncUp);
         } catch (err) {
+          if (err instanceof FetchError && (err as FetchError).cause === "abort") {
+            continue;
+          }
+
           this.options.logger.autoPollConfigServiceErrorDuringPolling(err);
         }
 
@@ -141,9 +146,9 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
         }
       } catch (err) {
         this.options.logger.autoPollConfigServiceErrorDuringPolling(err);
+      } finally {
+        initialCacheSyncUp = null; // allow GC to collect the Promise and its result
       }
-
-      initialCacheSyncUp = null; // allow GC to collect the Promise and its result
     }
   }
 
@@ -157,13 +162,7 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
 
     const latestConfig = await (initialCacheSyncUp ?? this.syncUpWithCache());
     if (latestConfig.isExpired(this.pollExpirationMs)) {
-      // Even if the service gets disposed immediately, we allow the first refresh for backward compatibility,
-      // i.e. to not break usage patterns like this:
-      // ```
-      // client.getValueAsync("SOME_KEY", false, user).then(value => { /* ... */ });
-      // client.dispose();
-      // ```
-      if (initialCacheSyncUp ? !this.isOfflineExactly : !this.isOffline) {
+      if (!this.isOffline) {
         await this.refreshConfigCoreAsync(latestConfig, false);
         return; // postpone signalling initialization until `onConfigFetched`
       }

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -1,7 +1,7 @@
 import type { ConfigCatClientOptions, IConfigCatKernel, OptionsBase, OptionsForPollingMode } from "./ConfigCatClientOptions";
 import { AutoPollOptions, LazyLoadOptions, ManualPollOptions, PollingMode, PROXY_SDKKEY_PREFIX } from "./ConfigCatClientOptions";
 import type { LoggerWrapper } from "./ConfigCatLogger";
-import { FormattableLogMessage, LogLevel } from "./ConfigCatLogger";
+import { FormattableLogMessage, LogLevel, logMethodDebug } from "./ConfigCatLogger";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ClientCacheState, RefreshErrorCode, refreshResultFromFailure } from "./ConfigServiceBase";
 import type { FlagOverrides } from "./FlagOverrides";
@@ -320,7 +320,7 @@ export class ConfigCatClient implements IConfigCatClient {
   private static finalize(data: FinalizationData) {
     // Safeguard against situations where user forgets to dispose of the client instance.
 
-    data.logger?.debug("finalize() called.");
+    logMethodDebug(data.logger, "finalize");
 
     if (data.cacheToken) {
       clientInstanceCache.remove(data.sdkKey, data.cacheToken);
@@ -330,7 +330,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   private static close(configService: IConfigService | null, logger?: LoggerWrapper, hooks?: Hooks) {
-    logger?.debug("close() called.");
+    logMethodDebug(logger, "close");
 
     hooks?.tryDisconnect();
     configService?.dispose();
@@ -338,7 +338,7 @@ export class ConfigCatClient implements IConfigCatClient {
 
   dispose(): void {
     const options = this.options;
-    options.logger.debug("dispose() called.");
+    logMethodDebug(options.logger, "dispose");
 
     if (this.cacheToken) {
       clientInstanceCache.remove(options.sdkKey, this.cacheToken);
@@ -368,7 +368,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getValueAsync<T extends SettingValue>(key: string, defaultValue: T, user?: IUser): Promise<SettingTypeOf<T>> {
-    this.options.logger.debug("getValueAsync() called.");
+    logMethodDebug(this.options.logger, "getValueAsync");
 
     validateSettingKey(key);
     ensureAllowedDefaultValue(defaultValue);
@@ -394,7 +394,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getValueDetailsAsync<T extends SettingValue>(key: string, defaultValue: T, user?: IUser): Promise<EvaluationDetails<SettingTypeOf<T>>> {
-    this.options.logger.debug("getValueDetailsAsync() called.");
+    logMethodDebug(this.options.logger, "getValueDetailsAsync");
 
     validateSettingKey(key);
     ensureAllowedDefaultValue(defaultValue);
@@ -418,7 +418,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getAllKeysAsync(): Promise<string[]> {
-    this.options.logger.debug("getAllKeysAsync() called.");
+    logMethodDebug(this.options.logger, "getAllKeysAsync");
 
     const defaultReturnValue = "empty array";
     try {
@@ -434,7 +434,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getAllValuesAsync(user?: IUser): Promise<SettingKeyValue[]> {
-    this.options.logger.debug("getAllValuesAsync() called.");
+    logMethodDebug(this.options.logger, "getAllValuesAsync");
 
     validateUserObject(user);
 
@@ -463,7 +463,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getAllValueDetailsAsync(user?: IUser): Promise<EvaluationDetails[]> {
-    this.options.logger.debug("getAllValueDetailsAsync() called.");
+    logMethodDebug(this.options.logger, "getAllValueDetailsAsync");
 
     validateUserObject(user);
 
@@ -491,7 +491,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getKeyAndValueAsync(variationId: string): Promise<SettingKeyValue | null> {
-    this.options.logger.debug("getKeyAndValueAsync() called.");
+    logMethodDebug(this.options.logger, "getKeyAndValueAsync");
 
     validateVariationId(variationId);
 
@@ -506,7 +506,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async forceRefreshAsync(): Promise<RefreshResult> {
-    this.options.logger.debug("forceRefreshAsync() called.");
+    logMethodDebug(this.options.logger, "forceRefreshAsync");
 
     if (this.configService) {
       try {
@@ -585,7 +585,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   private async getSettingsAsync(): Promise<SettingsWithRemoteConfig> {
-    this.options.logger.debug("getSettingsAsync() called.");
+    logMethodDebug(this.options.logger, "getSettingsAsync");
 
     const getRemoteConfigAsync: () => Promise<SettingsWithRemoteConfig> = async () => {
       const config = await this.configService!.getConfigAsync();
@@ -693,7 +693,7 @@ class Snapshot implements IConfigCatClientSnapshot {
   getAllKeys() { return this.mergedSettings ? Object.keys(this.mergedSettings) : []; }
 
   getValue<T extends SettingValue>(key: string, defaultValue: T, user?: IUser): SettingTypeOf<T> {
-    this.options.logger.debug("Snapshot.getValue() called.");
+    logMethodDebug(this.options.logger, "Snapshot.getValue");
 
     validateSettingKey(key);
     ensureAllowedDefaultValue(defaultValue);
@@ -716,7 +716,7 @@ class Snapshot implements IConfigCatClientSnapshot {
   }
 
   getValueDetails<T extends SettingValue>(key: string, defaultValue: T, user?: IUser): EvaluationDetails<SettingTypeOf<T>> {
-    this.options.logger.debug("Snapshot.getValueDetails() called.");
+    logMethodDebug(this.options.logger, "Snapshot.getValueDetails");
 
     validateSettingKey(key);
     ensureAllowedDefaultValue(defaultValue);
@@ -737,7 +737,7 @@ class Snapshot implements IConfigCatClientSnapshot {
   }
 
   getKeyAndValue(variationId: string): SettingKeyValue | null {
-    this.options.logger.debug("Snapshot.getKeyAndValue() called.");
+    logMethodDebug(this.options.logger, "Snapshot.getKeyAndValue");
 
     validateVariationId(variationId);
 

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -13,7 +13,7 @@ import type { EvaluationDetails, IRolloutEvaluator, SettingKeyValue, SettingType
 import { checkSettingsAvailable, evaluate, evaluateAll, evaluationDetailsFromDefaultValue, findKeyAndValue, getEvaluationErrorCode, RolloutEvaluator } from "./RolloutEvaluator";
 import type { IUser } from "./User";
 import { getUserAttributes } from "./User";
-import { createMap, createWeakRef, ensureEnumArg, ensureObjectArg, ensureStringArg, errorToString, isObject, shallowClone, throwInvalidArg, toStringSafe } from "./Utils";
+import { createMap, createWeakRef, ensureEnumArg, ensureObjectArg, ensureStringArg, errorToString, isObject, shallowClone, startsWith, throwInvalidArg, toStringSafe } from "./Utils";
 
 /** ConfigCat SDK client. */
 export interface IConfigCatClient extends IProvidesHooks {
@@ -752,8 +752,7 @@ class Snapshot implements IConfigCatClientSnapshot {
 }
 
 function isValidSdkKey(sdkKey: string, customBaseUrl: boolean) {
-  // NOTE: String.prototype.startsWith was introduced after ES5. We'd rather work around it instead of polyfilling it.
-  if (customBaseUrl && sdkKey.length > PROXY_SDKKEY_PREFIX.length && sdkKey.lastIndexOf(PROXY_SDKKEY_PREFIX, 0) === 0) {
+  if (customBaseUrl && sdkKey.length > PROXY_SDKKEY_PREFIX.length && startsWith(sdkKey, PROXY_SDKKEY_PREFIX)) {
     return true;
   }
 

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -292,7 +292,9 @@ export abstract class OptionsBase {
     }
 
     if ((this.baseUrlOverriden = baseUrl != null)) {
-      this.baseUrl = baseUrl!;
+      // Strip potential query string and/or fragment from the user-provided URL.
+      const index = indexOfAny(baseUrl, "?#");
+      this.baseUrl = index < 0 ? baseUrl : baseUrl.substring(0, index);
     } else {
       this.baseUrl = this.dataGovernance === DataGovernance.EuOnly
         ? "https://cdn-eu.configcat.com"
@@ -321,7 +323,7 @@ export abstract class OptionsBase {
     const { baseUrl } = this;
     return baseUrl
       + (baseUrl.charCodeAt(baseUrl.length - 1) !== 0x2F /*'/'*/ ? "/" : "")
-      + "configuration-files/" + this.sdkKey + "/" + OptionsBase.configFileName + "?sdk=" + this.clientVersion;
+      + "configuration-files/" + this.sdkKey + "/" + OptionsBase.configFileName;
   }
 
   getCacheKey(): string {
@@ -338,9 +340,20 @@ export function isCdnUrl(url: string): boolean {
   if (!CDN_BASEURL_REGEXP.test(url)) {
     return false;
   }
+
   let index = indexOfAny(url, "?#");
-  index = url.lastIndexOf(PROXY_PATH_SEGMENT, (index >= 0 ? index : url.length) - PROXY_PATH_SEGMENT.length);
-  return index < 0;
+  if (index >= 0) url = url.substring(0, index);
+
+  index = url.indexOf("/", url.indexOf("://") + 3);
+  if (index < 0) return true;
+
+  if (url.indexOf("%", index + 1) < 0) {
+    index = url.lastIndexOf(PROXY_PATH_SEGMENT, url.length - PROXY_PATH_SEGMENT.length);
+    return index < 0;
+  } else {
+    const decodedPathSegments = url.substring(index + 1).split("/").map(item => decodeURIComponent(item));
+    return decodedPathSegments.indexOf(PROXY_PATH_SEGMENT.slice(1, PROXY_PATH_SEGMENT.length - 1)) < 0;
+  }
 }
 
 export class AutoPollOptions extends OptionsBase {

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -16,7 +16,7 @@ import { LazyLoadConfigService } from "./LazyLoadConfigService";
 import { ManualPollConfigService } from "./ManualPollConfigService";
 import { ProjectConfig } from "./ProjectConfig";
 import type { IUser } from "./User";
-import { createMap, createWeakRef, ensureBooleanArg, ensureEnumArg, ensureFunctionArg, ensureNumberArgInRange, ensureObjectArg, ensureStringArg, isNumberInRange } from "./Utils";
+import { createMap, createWeakRef, ensureBooleanArg, ensureEnumArg, ensureFunctionArg, ensureNumberArgInRange, ensureObjectArg, ensureStringArg, indexOfAny, isNumberInRange } from "./Utils";
 
 export const PROXY_SDKKEY_PREFIX = "configcat-proxy/";
 
@@ -338,7 +338,7 @@ export function isCdnUrl(url: string): boolean {
   if (!CDN_BASEURL_REGEXP.test(url)) {
     return false;
   }
-  let index = url.indexOf("?");
+  let index = indexOfAny(url, "?#");
   index = url.lastIndexOf(PROXY_PATH_SEGMENT, (index >= 0 ? index : url.length) - PROXY_PATH_SEGMENT.length);
   return index < 0;
 }

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -91,13 +91,15 @@ export interface IOptions {
    * If not set, a default implementation will be used depending on the current platform.
    * If you want to use custom a config fetcher, you can provide an implementation of `IConfigCatConfigFetcher`.
    *
-   * @remarks Implementing a config fetcher that makes HTTP requests to the ConfigCat CDN is tricky, especially when the
-   * SDK runs in a browser. Therefore, please **avoid writing actual config fetcher implementations from scratch**
+   * @remarks Please note that the SDK does not dispose externally created config fetcher instances.
+   *
+   * Also be aware that implementing a config fetcher that makes HTTP requests to the ConfigCat CDN is tricky, especially when
+   * the SDK runs in a browser. Therefore, please **avoid writing actual config fetcher implementations from scratch**
    * unless absolutely necessary and you know exactly what you are doing. (Writing mock implementations for testing
    * purposes is fine, of course.)
    *
-   * If you use the SDK with a {@link https://configcat.com/docs/advanced/proxy/proxy-overview/ | proxy } and need to set
-   * custom HTTP request headers, you can subclass the built-in config fetcher implementations (e.g. FetchApiConfigFetcher)
+   * If you use the SDK with {@link https://configcat.com/docs/advanced/proxy/proxy-overview/ | ConfigCat Proxy } and need to set
+   * custom HTTP request headers, you can subclass the built-in config fetcher implementations (e.g. `ServerSideFetchApiConfigFetcher`)
    * and override the `setRequestHeaders` method.
    */
   configFetcher?: IConfigCatConfigFetcher | null;
@@ -184,13 +186,14 @@ export abstract class OptionsBase {
 
   baseUrl: string;
 
-  baseUrlOverriden;
+  baseUrlOverriden: boolean;
 
   dataGovernance = DataGovernance.Global;
 
   cache: IConfigCache;
 
   configFetcher: IConfigCatConfigFetcher;
+  ownsConfigFetcher: boolean;
 
   flagOverrides: FlagOverrides | null = null;
 
@@ -303,6 +306,7 @@ export abstract class OptionsBase {
       : (kernel.defaultCacheFactory?.(this) ?? new InMemoryConfigCache());
 
     this.configFetcher = configFetcher ?? kernel.configFetcherFactory(this);
+    this.ownsConfigFetcher = !configFetcher;
   }
 
   yieldHooks(): Hooks {

--- a/src/ConfigCatLogger.ts
+++ b/src/ConfigCatLogger.ts
@@ -141,6 +141,8 @@ export class LoggerWrapper implements IConfigCatLogger {
     this.log(LogLevel.Debug, 0, message, exception);
   }
 
+  get ifDebug(): LoggerWrapper | undefined { return this.isEnabled(LogLevel.Debug) ? this : void 0; }
+
   /* Common error messages (1000-1999) */
 
   configJsonIsNotPresent(defaultReturnValue: string): LogMessage {
@@ -425,6 +427,10 @@ export class LoggerWrapper implements IConfigCatLogger {
 
   /* SDK-specific info messages (6000-6999) */
 
+}
+
+export function logMethodDebug(logger: LoggerWrapper | undefined, methodName: string, message?: string): void {
+  logger?.debug(`${methodName}()${message ? ":" : ""} ${message ?? "called."}`);
 }
 
 export class ConfigCatConsoleLogger implements IConfigCatLogger {

--- a/src/ConfigCatLogger.ts
+++ b/src/ConfigCatLogger.ts
@@ -229,19 +229,27 @@ export class LoggerWrapper implements IConfigCatLogger {
     );
   }
 
-  fetchFailedDueToRequestTimeout(timeoutMs: number, ex: any): LogMessage {
+  fetchFailedDueToRequestTimeout(timeoutMs: number, ex: any, rayId: string | undefined): LogMessage {
     return this.log(
       LogLevel.Error, 1102,
-      FormattableLogMessage.from(
-        "TIMEOUT"
-      )`Request timed out while trying to fetch config JSON. Timeout value: ${timeoutMs}ms`,
+      rayId == null
+        ? FormattableLogMessage.from(
+          "TIMEOUT"
+        )`Request timed out while trying to fetch config JSON. Timeout value: ${timeoutMs}ms`
+        : FormattableLogMessage.from(
+          "TIMEOUT", "RAY_ID"
+        )`Request timed out while trying to fetch config JSON. Timeout value: ${timeoutMs}ms (Ray ID: ${rayId})`,
       ex);
   }
 
-  fetchFailedDueToUnexpectedError(ex: any): LogMessage {
+  fetchFailedDueToUnexpectedError(ex: any, rayId: string | undefined): LogMessage {
     return this.log(
       LogLevel.Error, 1103,
-      "Unexpected error occurred while trying to fetch config JSON. It is most likely due to a local network issue. Please make sure your application can reach the ConfigCat CDN servers (or your proxy server) over HTTP.",
+      rayId == null
+        ? "Unexpected error occurred while trying to fetch config JSON. It is most likely due to a local network issue. Please make sure your application can reach the ConfigCat CDN servers (or your proxy server) over HTTP."
+        : FormattableLogMessage.from(
+          "RAY_ID"
+        )`Unexpected error occurred while trying to fetch config JSON. It is most likely due to a local network issue. Please make sure your application can reach the ConfigCat CDN servers (or your proxy server) over HTTP. (Ray ID: ${rayId})`,
       ex
     );
   }

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -1,3 +1,4 @@
+import type { LoggerWrapper } from "./ConfigCatLogger";
 import type { RefreshErrorCode } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
 import type { Message } from "./Utils";
@@ -134,3 +135,5 @@ export interface IConfigCatConfigFetcher {
    */
   fetchAsync(request: FetchRequest): Promise<FetchResponse>;
 }
+
+export const fetchInternalAsyncMethodName = "fetchInternalAsync";

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -118,7 +118,7 @@ export type FetchErrorCauses = {
   failure: [err?: any];
 };
 
-type FetchErrorArgsInternal<TCause extends keyof FetchErrorCauses> = [...FetchErrorCauses[TCause], rayId?: string];
+type FetchErrorArgsInternal<TCause extends keyof FetchErrorCauses> = [...FetchErrorCauses[TCause], /* rayId: */ string?];
 
 export type FetchErrorCtorInternal<TCause extends keyof FetchErrorCauses = keyof FetchErrorCauses> =
   new(cause: TCause, ...args: FetchErrorArgsInternal<TCause>) => FetchError<TCause>;

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -2,7 +2,13 @@ import type { LoggerWrapper } from "./ConfigCatLogger";
 import type { RefreshErrorCode } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
 import type { Message } from "./Utils";
-import { ensurePrototype, toStringSafe } from "./Utils";
+import { ensurePrototype, indexOfAny, toStringSafe } from "./Utils";
+
+export const USER_AGENT_HEADER_NAME = "User-Agent";
+export const CONFIGCAT_USER_AGENT_HEADER_NAME = "X-ConfigCat-UserAgent";
+
+export const SDK_QUERYPARAM_NAME = "sdk";
+export const ETAG_QUERYPARAM_NAME = "ccetag";
 
 export const enum FetchStatus {
   Fetched = 0,
@@ -165,12 +171,48 @@ export interface IConfigCatConfigFetcher {
   dispose?(): void;
 }
 
+let normalizedUserAgentHeaderName: string | undefined;
+let normalizedConfigCatUserAgentHeaderName: string | undefined;
+
+export function adjustUrlForBrowser(url: string, request: FetchRequest): string {
+  const { lastETag, headers } = request;
+
+  normalizedUserAgentHeaderName ??= USER_AGENT_HEADER_NAME.toLowerCase();
+  normalizedConfigCatUserAgentHeaderName ??= CONFIGCAT_USER_AGENT_HEADER_NAME.toLowerCase();
+
+  let userAgentHeaderValue: string | undefined;
+  for (const [key, value] of headers) {
+    const normalizedKey = key.toLowerCase();
+    if (normalizedKey === normalizedUserAgentHeaderName || normalizedKey === normalizedConfigCatUserAgentHeaderName) {
+      userAgentHeaderValue = value;
+      break;
+    }
+  }
+
+  const sdkQueryParamValue = encodeURIComponent(userAgentHeaderValue ?? "");
+
+  // NOTE: We are sending the etag as a query parameter so if the browser doesn't automatically adds
+  // the If-None-Match header, we can transform this query param to the header in our CDN provider.
+  // (Explicitly specifying the If-None-Match header would cause an unnecessary CORS OPTIONS request.)
+
+  let endIndex: number;
+  const index = indexOfAny(url, "?#");
+  const query = index < 0 || url.charCodeAt(index) !== 0x3F /*'?'*/
+    ? ""
+    : (endIndex = url.indexOf("#", index + 1), url.substring(index + 1, endIndex < 0 ? url.length : endIndex));
+  url = index < 0 ? url : url.substring(0, index);
+
+  return query ? `${url}?${SDK_QUERYPARAM_NAME}=${sdkQueryParamValue}&${ETAG_QUERYPARAM_NAME}=${encodeURIComponent(lastETag ?? "")}&${query}`
+    : lastETag ? `${url}?${SDK_QUERYPARAM_NAME}=${sdkQueryParamValue}&${ETAG_QUERYPARAM_NAME}=${encodeURIComponent(lastETag)}`
+    : `${url}?${SDK_QUERYPARAM_NAME}=${sdkQueryParamValue}`;
+}
+
 export const fetchInternalAsyncMethodName = "fetchInternalAsync";
 export type FetchInternalAsyncMethod<TFetcher extends IConfigCatConfigFetcher> =
   (this: TFetcher, request: FetchRequest, logger?: LoggerWrapper) => Promise<FetchResponse>;
 
-export const fetchRetryLimit = 1;
-export const fetchRetryDelayMs = 50;
-export const connectionPoolResetThresholdMs = 30_000;
+export const FETCH_RETRY_LIMIT = 1;
+export const FETCH_RETRY_DELAY_MS = 50;
+export const CONNECTIONPOOL_RESET_THRESHOLD_MS = 30_000;
 
-export const requestIdArgName = "REQUEST_ID";
+export const REQUEST_ID_ARG_NAME = "REQUEST_ID";

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -159,3 +159,5 @@ export type FetchInternalAsyncMethod<TFetcher extends IConfigCatConfigFetcher> =
 export const fetchRetryLimit = 1;
 export const fetchRetryDelayMs = 50;
 export const connectionPoolResetThresholdMs = 30_000;
+
+export const requestIdArgName = "REQUEST_ID";

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -42,6 +42,8 @@ export function fetchResultFromError(config: ProjectConfig,
 
 /** The request parameters for a ConfigCat config fetch operation. */
 export class FetchRequest {
+  private readonly _guard: unknown; // prevents structural compatibility with arbitrary objects
+
   constructor(
     /** The URL of the config. */
     readonly url: string,
@@ -90,6 +92,18 @@ export class FetchResponse {
       }
     }
   }
+
+  isExpected(): boolean {
+    switch (this.statusCode) {
+      case 200: // OK
+      case 304: // Not Modified
+      case 403: // Forbidden
+      case 404: // Not Found
+        return true;
+    }
+
+    return false;
+  }
 }
 
 export type FetchErrorCauses = {
@@ -137,3 +151,8 @@ export interface IConfigCatConfigFetcher {
 }
 
 export const fetchInternalAsyncMethodName = "fetchInternalAsync";
+export type FetchInternalAsyncMethodType<TFetcher extends IConfigCatConfigFetcher> =
+  (this: TFetcher, request: FetchRequest, logger?: LoggerWrapper) => Promise<FetchResponse>;
+
+export const fetchRetryLimit = 1;
+export const fetchRetryDelayMs = 50;

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -112,30 +112,43 @@ export type FetchErrorCauses = {
   failure: [err?: any];
 };
 
+type FetchErrorArgsInternal<TCause extends keyof FetchErrorCauses> = [...FetchErrorCauses[TCause], rayId?: string];
+
+export type FetchErrorCtorInternal<TCause extends keyof FetchErrorCauses = keyof FetchErrorCauses> =
+  new(cause: TCause, ...args: FetchErrorArgsInternal<TCause>) => FetchError<TCause>;
+
 export class FetchError<TCause extends keyof FetchErrorCauses = keyof FetchErrorCauses> extends Error {
   override readonly name = FetchError.name;
   readonly args: FetchErrorCauses[TCause];
+  private readonly rayId: string | undefined;
 
   constructor(public cause: TCause, ...args: FetchErrorCauses[TCause]) {
-    super(((cause: TCause, args: FetchErrorCauses[TCause]): string | undefined => {
-      switch (cause) {
-        case "abort":
-          return "Request was aborted.";
-        case "timeout":
-          const [timeoutMs] = args as FetchErrorCauses["timeout"];
-          return `Request timed out. Timeout value: ${timeoutMs}ms`;
-        case "failure":
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const [err] = args as FetchErrorCauses["failure"];
-          const message = "Request failed due to a network or protocol error.";
-          return err
-            ? message + " " + (err instanceof Error ? err.message : toStringSafe(err))
-            : message;
-      }
-    })(cause, args));
+    let message: string, rayId: string | undefined;
+    switch (cause) {
+      case "abort":
+        [rayId] = args as FetchErrorArgsInternal<"abort">;
+        message = "Request was aborted.";
+        break;
+      case "timeout":
+        let timeoutMs: number;
+        [timeoutMs, rayId] = args as FetchErrorArgsInternal<"timeout">;
+        message = `Request timed out. Timeout value: ${timeoutMs}ms`;
+        break;
+      case "failure":
+        let err: any;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        [err, rayId] = args as FetchErrorArgsInternal<"failure">;
+        message = "Request failed due to a network or protocol error.";
+        message = err
+          ? message + " " + (err instanceof Error ? err.message : toStringSafe(err))
+          : message;
+        break;
+    }
+    super(message);
 
     ensurePrototype(this, FetchError);
     this.args = args;
+    this.rayId = rayId;
   }
 }
 

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -158,3 +158,4 @@ export type FetchInternalAsyncMethod<TFetcher extends IConfigCatConfigFetcher> =
 
 export const fetchRetryLimit = 1;
 export const fetchRetryDelayMs = 50;
+export const connectionPoolResetThresholdMs = 30_000;

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -171,6 +171,13 @@ export interface IConfigCatConfigFetcher {
   dispose?(): void;
 }
 
+export function getRequestHeaders(clientVersion: string): [string, string][] {
+  return [
+    [USER_AGENT_HEADER_NAME, clientVersion],
+    [CONFIGCAT_USER_AGENT_HEADER_NAME, clientVersion],
+  ];
+}
+
 let normalizedUserAgentHeaderName: string | undefined;
 let normalizedConfigCatUserAgentHeaderName: string | undefined;
 

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -148,10 +148,12 @@ export interface IConfigCatConfigFetcher {
    * @throws {FetchErrorException} The fetch operation failed.
    */
   fetchAsync(request: FetchRequest): Promise<FetchResponse>;
+
+  dispose?(): void;
 }
 
 export const fetchInternalAsyncMethodName = "fetchInternalAsync";
-export type FetchInternalAsyncMethodType<TFetcher extends IConfigCatConfigFetcher> =
+export type FetchInternalAsyncMethod<TFetcher extends IConfigCatConfigFetcher> =
   (this: TFetcher, request: FetchRequest, logger?: LoggerWrapper) => Promise<FetchResponse>;
 
 export const fetchRetryLimit = 1;

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -2,10 +2,10 @@ import type { CacheSyncResult } from "./ConfigCatCache";
 import { ExternalConfigCache, InMemoryConfigCache } from "./ConfigCatCache";
 import type { ConfigCatClient } from "./ConfigCatClient";
 import type { OptionsBase } from "./ConfigCatClientOptions";
-import type { LogMessage } from "./ConfigCatLogger";
+import type { LoggerWrapper, LogMessage } from "./ConfigCatLogger";
 import { toMessage } from "./ConfigCatLogger";
 import type { FetchErrorCauses, FetchResponse, FetchResult, IConfigCatConfigFetcher } from "./ConfigFetcher";
-import { FetchError, FetchRequest, fetchResultFromError, fetchResultFromNotModified, fetchResultFromSuccess, FetchStatus } from "./ConfigFetcher";
+import { FetchError, fetchInternalAsyncMethodName, FetchRequest, fetchResultFromError, fetchResultFromNotModified, fetchResultFromSuccess, FetchStatus } from "./ConfigFetcher";
 import { RedirectMode } from "./ConfigJson";
 import type { Config } from "./ProjectConfig";
 import { deserializeConfig, prepareConfig, ProjectConfig } from "./ProjectConfig";
@@ -306,7 +306,16 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       options.logger.debug(`ConfigServiceBase.fetchRequestAsync(): calling fetchLogic()${retryNumber > 0 ? `, retry ${retryNumber}/${maxRetryCount}` : ""}.`);
 
       const request = new FetchRequest(options.getUrl(), lastETag, this.requestHeaders, options.requestTimeoutMs);
-      const response = await this.configFetcher.fetchAsync(request);
+
+      interface IConfigFetcherInternal {
+        [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse>;
+      }
+
+      const response = await (
+        (this.configFetcher as Partial<IConfigFetcherInternal>)[fetchInternalAsyncMethodName]
+          ? (this.configFetcher as unknown as IConfigFetcherInternal)[fetchInternalAsyncMethodName](request, this.options.logger)
+          : this.configFetcher.fetchAsync(request)
+      );
 
       if (response.statusCode !== 200) {
         return [response];

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -141,6 +141,8 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
   protected readonly cacheKey: string;
 
   protected readonly configFetcher: IConfigCatConfigFetcher;
+  private readonly ownsConfigFetcher: boolean;
+
   private readonly requestHeaders: ReadonlyArray<readonly [string, string]>;
 
   abstract readonly readyPromise: Promise<ClientCacheState>;
@@ -151,6 +153,8 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     this.cacheKey = options.getCacheKey();
 
     this.configFetcher = options.configFetcher;
+    this.ownsConfigFetcher = options.ownsConfigFetcher;
+
     this.requestHeaders = [
       ["User-Agent", options.clientVersion],
       ["X-ConfigCat-UserAgent", options.clientVersion],
@@ -168,7 +172,13 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
   }
 
   dispose(): void {
-    this.status = ConfigServiceStatus.Disposed;
+    if (this.status !== ConfigServiceStatus.Disposed) {
+      this.status = ConfigServiceStatus.Disposed;
+
+      if (this.ownsConfigFetcher) {
+        this.configFetcher.dispose?.();
+      }
+    }
   }
 
   protected get disposed(): boolean {

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -289,7 +289,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       }
     } catch (err) {
       let errorCode: RefreshErrorCode;
-      [errorCode, errorMessage] = err instanceof FetchError && err.cause === "timeout"
+      [errorCode, errorMessage] = err instanceof FetchError && (err as FetchError).cause === "timeout"
         ? [RefreshErrorCode.HttpRequestTimeout, options.logger.fetchFailedDueToRequestTimeout((err.args as FetchErrorCauses["timeout"])[0], err)]
         : [RefreshErrorCode.HttpRequestFailure, options.logger.fetchFailedDueToUnexpectedError(err)];
 

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -5,7 +5,7 @@ import type { OptionsBase } from "./ConfigCatClientOptions";
 import type { LogMessage } from "./ConfigCatLogger";
 import { logMethodDebug, toMessage } from "./ConfigCatLogger";
 import type { FetchErrorCauses, FetchInternalAsyncMethod, FetchResponse, FetchResult, IConfigCatConfigFetcher } from "./ConfigFetcher";
-import { CONFIGCAT_USER_AGENT_HEADER_NAME, FetchError, fetchInternalAsyncMethodName, FetchRequest, fetchResultFromError, fetchResultFromNotModified, fetchResultFromSuccess, FetchStatus, USER_AGENT_HEADER_NAME } from "./ConfigFetcher";
+import { FetchError, fetchInternalAsyncMethodName, FetchRequest, fetchResultFromError, fetchResultFromNotModified, fetchResultFromSuccess, FetchStatus, getRequestHeaders } from "./ConfigFetcher";
 import { RedirectMode } from "./ConfigJson";
 import type { Config } from "./ProjectConfig";
 import { deserializeConfig, prepareConfig, ProjectConfig } from "./ProjectConfig";
@@ -155,10 +155,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     this.configFetcher = options.configFetcher;
     this.ownsConfigFetcher = options.ownsConfigFetcher;
 
-    this.requestHeaders = [
-      [USER_AGENT_HEADER_NAME, options.clientVersion],
-      [CONFIGCAT_USER_AGENT_HEADER_NAME, options.clientVersion],
-    ];
+    this.requestHeaders = getRequestHeaders(options.clientVersion);
 
     this.status = options.offline ? ConfigServiceStatus.Offline : ConfigServiceStatus.Online;
   }

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -2,9 +2,9 @@ import type { CacheSyncResult } from "./ConfigCatCache";
 import { ExternalConfigCache, InMemoryConfigCache } from "./ConfigCatCache";
 import type { ConfigCatClient } from "./ConfigCatClient";
 import type { OptionsBase } from "./ConfigCatClientOptions";
-import type { LoggerWrapper, LogMessage } from "./ConfigCatLogger";
+import type { LogMessage } from "./ConfigCatLogger";
 import { logMethodDebug, toMessage } from "./ConfigCatLogger";
-import type { FetchErrorCauses, FetchResponse, FetchResult, IConfigCatConfigFetcher } from "./ConfigFetcher";
+import type { FetchErrorCauses, FetchInternalAsyncMethod, FetchResponse, FetchResult, IConfigCatConfigFetcher } from "./ConfigFetcher";
 import { FetchError, fetchInternalAsyncMethodName, FetchRequest, fetchResultFromError, fetchResultFromNotModified, fetchResultFromSuccess, FetchStatus } from "./ConfigFetcher";
 import { RedirectMode } from "./ConfigJson";
 import type { Config } from "./ProjectConfig";
@@ -325,13 +325,13 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
       const request = new FetchRequest(options.getUrl(), lastETag, this.requestHeaders, options.requestTimeoutMs);
 
-      interface IConfigFetcherInternal {
-        [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse>;
+      interface IConfigFetcherInternal extends IConfigCatConfigFetcher {
+        [fetchInternalAsyncMethodName]: FetchInternalAsyncMethod<IConfigCatConfigFetcher>;
       }
 
       const response = await (
         (this.configFetcher as Partial<IConfigFetcherInternal>)[fetchInternalAsyncMethodName]
-          ? (this.configFetcher as unknown as IConfigFetcherInternal)[fetchInternalAsyncMethodName](request, this.options.logger)
+          ? (this.configFetcher as IConfigFetcherInternal)[fetchInternalAsyncMethodName](request, this.options.logger)
           : this.configFetcher.fetchAsync(request)
       );
 

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -135,8 +135,8 @@ function nameOfConfigServiceStatus(value: ConfigServiceStatus): string {
 export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
   private status: ConfigServiceStatus;
 
-  private pendingCacheSyncUp: Promise<ProjectConfig> | null = null;
-  private pendingConfigRefresh: Promise<[FetchResult, ProjectConfig]> | null = null;
+  private pendingCacheSyncUp: Promise<[ProjectConfig | undefined, err?: any]> | null = null;
+  private pendingConfigRefresh: Promise<[FetchResult | undefined, ProjectConfig, err?: any]> | null = null;
 
   protected readonly cacheKey: string;
 
@@ -199,7 +199,17 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     }
   }
 
-  protected refreshConfigCoreAsync(latestConfig: ProjectConfig, isInitiatedByUser: boolean): Promise<[FetchResult, ProjectConfig]> {
+  protected async refreshConfigCoreAsync(latestConfig: ProjectConfig, isInitiatedByUser: boolean): Promise<[FetchResult, ProjectConfig]> {
+    let fetchResult: FetchResult | undefined, err: unknown;
+    [fetchResult, latestConfig, err] = await this.beginConfigRefreshOrJoinPending(latestConfig, isInitiatedByUser);
+    if (fetchResult) {
+      return [fetchResult, latestConfig];
+    } else {
+      throw err;
+    }
+  }
+
+  private beginConfigRefreshOrJoinPending(latestConfig: ProjectConfig, isInitiatedByUser: boolean): Promise<[FetchResult | undefined, ProjectConfig, err?: unknown]> {
     if (this.pendingConfigRefresh) {
       // NOTE: Joiners may obtain more up-to-date config data from the external cache than the `latestConfig`
       // that was used to initiate the fetch operation. However, we ignore this possibility because we consider
@@ -209,30 +219,39 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       return this.pendingConfigRefresh;
     }
 
-    const configRefreshPromise = (async (latestConfig: ProjectConfig): Promise<[FetchResult, ProjectConfig]> => {
-      const fetchResult = await this.fetchAsync(latestConfig);
+    const configRefreshPromise = (async (latestConfig: ProjectConfig): Promise<[FetchResult | undefined, ProjectConfig, err?: unknown]> => {
+      // NOTE: This function must never result in a rejected promise, otherwise some runtimes like Node.js or Deno may
+      // detect it as unhandled promise rejection and terminate the process (see also https://stackoverflow.com/a/77505185/8656352).
+      // Thus, we need to wrap all the code here in try-catch and propagate the potential error as data.
 
-      const shouldUpdateCache =
-        fetchResult.status === FetchStatus.Fetched
-        || fetchResult.status === FetchStatus.NotModified
-        || fetchResult.config.timestamp > latestConfig.timestamp // is not transient error?
-          && (!fetchResult.config.isEmpty || this.options.cache.getInMemory().isEmpty);
+      try {
+        const fetchResult = await this.fetchAsync(latestConfig);
 
-      if (shouldUpdateCache) {
-        // NOTE: `ExternalConfigCache.set` makes sure that the external cache is not overwritten with empty
-        // config data under any circumstances.
-        await this.options.cache.set(this.cacheKey, fetchResult.config);
+        const shouldUpdateCache =
+          fetchResult.status === FetchStatus.Fetched
+          || fetchResult.status === FetchStatus.NotModified
+          || fetchResult.config.timestamp > latestConfig.timestamp // is not transient error?
+            && (!fetchResult.config.isEmpty || this.options.cache.getInMemory().isEmpty);
 
-        latestConfig = fetchResult.config;
+        if (shouldUpdateCache) {
+          // NOTE: `ExternalConfigCache.set` makes sure that the external cache is not overwritten with empty
+          // config data under any circumstances.
+          await this.options.cache.set(this.cacheKey, fetchResult.config);
+
+          latestConfig = fetchResult.config;
+        }
+
+        this.onConfigFetched(fetchResult, isInitiatedByUser);
+
+        if (fetchResult.status === FetchStatus.Fetched) {
+          this.onConfigChanged(fetchResult.config);
+        }
+
+        return [fetchResult, latestConfig];
+      } catch (err) {
+        // eslint-disable-next-line no-sparse-arrays
+        return [, latestConfig, err];
       }
-
-      this.onConfigFetched(fetchResult, isInitiatedByUser);
-
-      if (fetchResult.status === FetchStatus.Fetched) {
-        this.onConfigChanged(fetchResult.config);
-      }
-
-      return [fetchResult, latestConfig];
     })(latestConfig);
 
     this.pendingConfigRefresh = configRefreshPromise;
@@ -437,25 +456,40 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       return cache.get(this.cacheKey);
     }
 
-    if (this.pendingCacheSyncUp) {
-      return this.pendingCacheSyncUp;
+    let cacheSyncUpPromise = this.pendingCacheSyncUp;
+
+    if (!cacheSyncUpPromise) {
+      const syncResult = cache.get(this.cacheKey);
+      if (!isPromiseLike(syncResult)) {
+        return this.onCacheSynced(syncResult);
+      }
+
+      // NOTE: This call chain must never result in a rejected promise, otherwise some runtimes like Node.js or Deno may
+      // detect it as unhandled promise rejection and terminate the process (see also https://stackoverflow.com/a/77505185/8656352).
+      // Thus, we need to make sure that potential error is catched and propagate it as data.
+      cacheSyncUpPromise = syncResult
+        .then(syncResult => [this.onCacheSynced(syncResult)] as [ProjectConfig])
+        .catch((err: unknown) => {
+          // eslint-disable-next-line no-sparse-arrays
+          return [, err];
+        });
+
+      this.pendingCacheSyncUp = cacheSyncUpPromise;
+      try {
+        cacheSyncUpPromise.finally(() => this.pendingCacheSyncUp = null);
+      } catch (err) {
+        this.pendingCacheSyncUp = null;
+        throw err;
+      }
     }
 
-    const syncResult = cache.get(this.cacheKey);
-    if (!isPromiseLike(syncResult)) {
-      return this.onCacheSynced(syncResult);
-    }
-
-    const cacheSyncUpPromise = syncResult.then(syncResult => this.onCacheSynced(syncResult));
-
-    this.pendingCacheSyncUp = cacheSyncUpPromise;
-    try {
-      cacheSyncUpPromise.finally(() => this.pendingCacheSyncUp = null);
-    } catch (err) {
-      this.pendingCacheSyncUp = null;
-      throw err;
-    }
-    return cacheSyncUpPromise;
+    return cacheSyncUpPromise.then(([projectConfig, err]) => {
+      if (projectConfig) {
+        return projectConfig;
+      } else {
+        throw err;
+      }
+    });
   }
 
   private onCacheSynced(syncResult: CacheSyncResult): ProjectConfig {

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -298,22 +298,31 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
         default:
           errorMessage = options.logger.fetchFailedDueToUnexpectedHttpResponse(response.statusCode, response.reasonPhrase, response["rayId"]);
-          logMethodDebug(debugLogger, methodName, "fetch was unsuccessful. Returning null.");
+          logMethodDebug(debugLogger, methodName, "fetch was unsuccessful. Returning last config.");
           return fetchResultFromError(lastConfig, RefreshErrorCode.UnexpectedHttpResponse, toMessage(errorMessage));
       }
     } catch (err) {
       let errorCode: RefreshErrorCode;
 
       const fetchError = err instanceof FetchError ? err as FetchError : void 0;
-      if (fetchError && fetchError.cause === "timeout") {
-        errorMessage = options.logger.fetchFailedDueToRequestTimeout((fetchError.args as FetchErrorCauses["timeout"])[0], err, fetchError["rayId"]);
-        errorCode = RefreshErrorCode.HttpRequestTimeout;
-      } else {
-        errorMessage = options.logger.fetchFailedDueToUnexpectedError(err, fetchError?.["rayId"]);
-        errorCode = RefreshErrorCode.HttpRequestFailure;
+      // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+      switch (fetchError?.cause) {
+        case "abort":
+          // This should occur only when the client gets disposed while a fetch operation is in progress.
+          // Let the caller deal with this (either swallow it or report it as RefreshErrorCode.UnexpectedError)
+          logMethodDebug(debugLogger, methodName, "fetch was aborted. Propagating error.");
+          throw err;
+        case "timeout":
+          errorMessage = options.logger.fetchFailedDueToRequestTimeout((fetchError.args as FetchErrorCauses["timeout"])[0], err, fetchError["rayId"]);
+          errorCode = RefreshErrorCode.HttpRequestTimeout;
+          break;
+        default:
+          errorMessage = options.logger.fetchFailedDueToUnexpectedError(err, fetchError?.["rayId"]);
+          errorCode = RefreshErrorCode.HttpRequestFailure;
+          break;
       }
 
-      logMethodDebug(debugLogger, methodName, "fetch was unsuccessful. Returning null.");
+      logMethodDebug(debugLogger, methodName, "fetch was unsuccessful. Returning last config.");
       return fetchResultFromError(lastConfig, errorCode, toMessage(errorMessage), err);
     }
   }
@@ -396,10 +405,6 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
         return [response, config];
       }
     }
-  }
-
-  protected get isOfflineExactly(): boolean {
-    return this.status === ConfigServiceStatus.Offline;
   }
 
   get isOffline(): boolean {

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -3,7 +3,7 @@ import { ExternalConfigCache, InMemoryConfigCache } from "./ConfigCatCache";
 import type { ConfigCatClient } from "./ConfigCatClient";
 import type { OptionsBase } from "./ConfigCatClientOptions";
 import type { LoggerWrapper, LogMessage } from "./ConfigCatLogger";
-import { toMessage } from "./ConfigCatLogger";
+import { logMethodDebug, toMessage } from "./ConfigCatLogger";
 import type { FetchErrorCauses, FetchResponse, FetchResult, IConfigCatConfigFetcher } from "./ConfigFetcher";
 import { FetchError, fetchInternalAsyncMethodName, FetchRequest, fetchResultFromError, fetchResultFromNotModified, fetchResultFromSuccess, FetchStatus } from "./ConfigFetcher";
 import { RedirectMode } from "./ConfigJson";
@@ -172,6 +172,8 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
   }
 
   dispose(): void {
+    logMethodDebug(this.options.logger, "ConfigServiceBase.dispose");
+
     if (this.status !== ConfigServiceStatus.Disposed) {
       this.status = ConfigServiceStatus.Disposed;
 
@@ -258,7 +260,9 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
   private async fetchAsync(lastConfig: ProjectConfig): Promise<FetchResult> {
     const options = this.options;
-    options.logger.debug("ConfigServiceBase.fetchAsync() called.");
+    const methodName = "ConfigServiceBase.fetchAsync";
+    const debugLogger = this.options.logger.ifDebug;
+    logMethodDebug(debugLogger, methodName);
 
     let errorMessage: LogMessage;
     try {
@@ -269,32 +273,32 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
         case 200: // OK
           if (!config) {
             errorMessage = options.logger.fetchReceived200WithInvalidBody(response["rayId"], error);
-            options.logger.debug(`ConfigServiceBase.fetchAsync(): ${response.statusCode} ${response.reasonPhrase} was received but the HTTP response content was invalid. Returning null.`);
+            logMethodDebug(debugLogger, methodName, `${response.statusCode} ${response.reasonPhrase} was received but the HTTP response content was invalid. Returning null.`);
             return fetchResultFromError(lastConfig, RefreshErrorCode.InvalidHttpResponseContent, toMessage(errorMessage), error);
           }
 
-          options.logger.debug("ConfigServiceBase.fetchAsync(): fetch was successful. Returning new config.");
+          logMethodDebug(debugLogger, methodName, "fetch was successful. Returning new config.");
           return fetchResultFromSuccess(new ProjectConfig(response.body, config, ProjectConfig.generateTimestamp(), response.eTag));
 
         case 304: // Not Modified
           if (lastConfig.isEmpty) {
             errorMessage = options.logger.fetchReceived304WhenLocalCacheIsEmpty(response.statusCode, response.reasonPhrase, response["rayId"]);
-            options.logger.debug(`ConfigServiceBase.fetchAsync(): ${response.statusCode} ${response.reasonPhrase} was received when no config is cached locally. Returning null.`);
+            logMethodDebug(debugLogger, methodName, `${response.statusCode} ${response.reasonPhrase} was received when no config is cached locally. Returning null.`);
             return fetchResultFromError(lastConfig, RefreshErrorCode.InvalidHttpResponseWhenLocalCacheIsEmpty, toMessage(errorMessage));
           }
 
-          options.logger.debug("ConfigServiceBase.fetchAsync(): content was not modified. Returning last config with updated timestamp.");
+          logMethodDebug(debugLogger, methodName, "content was not modified. Returning last config with updated timestamp.");
           return fetchResultFromNotModified(lastConfig.with(ProjectConfig.generateTimestamp()));
 
         case 403: // Forbidden
         case 404: // Not Found
           errorMessage = options.logger.fetchFailedDueToInvalidSdkKey(options.sdkKey, response["rayId"]);
-          options.logger.debug("ConfigServiceBase.fetchAsync(): fetch was unsuccessful. Returning last config (if any) with updated timestamp.");
+          logMethodDebug(debugLogger, methodName, "fetch was unsuccessful. Returning last config (if any) with updated timestamp.");
           return fetchResultFromError(lastConfig.with(ProjectConfig.generateTimestamp()), RefreshErrorCode.InvalidSdkKey, toMessage(errorMessage));
 
         default:
           errorMessage = options.logger.fetchFailedDueToUnexpectedHttpResponse(response.statusCode, response.reasonPhrase, response["rayId"]);
-          options.logger.debug("ConfigServiceBase.fetchAsync(): fetch was unsuccessful. Returning null.");
+          logMethodDebug(debugLogger, methodName, "fetch was unsuccessful. Returning null.");
           return fetchResultFromError(lastConfig, RefreshErrorCode.UnexpectedHttpResponse, toMessage(errorMessage));
       }
     } catch (err) {
@@ -303,17 +307,21 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
         ? [RefreshErrorCode.HttpRequestTimeout, options.logger.fetchFailedDueToRequestTimeout((err.args as FetchErrorCauses["timeout"])[0], err)]
         : [RefreshErrorCode.HttpRequestFailure, options.logger.fetchFailedDueToUnexpectedError(err)];
 
-      options.logger.debug("ConfigServiceBase.fetchAsync(): fetch was unsuccessful. Returning null.");
+      logMethodDebug(debugLogger, methodName, "fetch was unsuccessful. Returning null.");
       return fetchResultFromError(lastConfig, errorCode, toMessage(errorMessage), err);
     }
   }
 
   private async fetchRequestAsync(lastETag: string | undefined, maxRetryCount = 2): Promise<[FetchResponse, Config?, any?]> {
     const options = this.options;
-    options.logger.debug("ConfigServiceBase.fetchRequestAsync() called.");
+    const methodName = "ConfigServiceBase.fetchRequestAsync";
+    const debugLogger = this.options.logger.ifDebug;
+    logMethodDebug(debugLogger, methodName);
 
     for (let retryNumber = 0; ; retryNumber++) {
-      options.logger.debug(`ConfigServiceBase.fetchRequestAsync(): calling fetchLogic()${retryNumber > 0 ? `, retry ${retryNumber}/${maxRetryCount}` : ""}.`);
+      logMethodDebug(debugLogger, methodName, retryNumber > 0
+        ? `calling fetchLogic(), retry ${retryNumber}/${maxRetryCount}.`
+        : "calling fetchLogic().");
 
       const request = new FetchRequest(options.getUrl(), lastETag, this.requestHeaders, options.requestTimeoutMs);
 
@@ -332,7 +340,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       }
 
       if (!response.body) {
-        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): no response body.");
+        logMethodDebug(debugLogger, methodName, "no response body.");
         return [response, void 0, Error("No response body.")];
       }
 
@@ -340,13 +348,13 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       try {
         config = deserializeConfig(response.body);
       } catch (err) {
-        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): invalid response body.");
+        logMethodDebug(debugLogger, methodName, "invalid response body.");
         return [response, void 0, err];
       }
 
       const preferences = config.p;
       if (!preferences) {
-        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): preferences are missing or invalid.");
+        logMethodDebug(debugLogger, methodName, "preferences are missing or invalid.");
         return [response, config];
       }
 
@@ -354,7 +362,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
       // If baseUrl is the same as the last known one, just return the response.
       if (baseUrl == null || baseUrl === options.baseUrl) {
-        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): baseUrl OK.");
+        logMethodDebug(debugLogger, methodName, "baseUrl OK.");
         return [response, config];
       }
 
@@ -363,7 +371,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       // If baseUrl is overridden, and the redirect parameter is not 2 (force),
       // the SDK should not redirect the calls and it just have to return the response.
       if (options.baseUrlOverriden && redirect !== RedirectMode.Force) {
-        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): options.baseUrlOverriden && redirect !== 2.");
+        logMethodDebug(debugLogger, methodName, "options.baseUrlOverriden && redirect !== RedirectMode.Force.");
         return [response, config];
       }
 

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -303,9 +303,15 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       }
     } catch (err) {
       let errorCode: RefreshErrorCode;
-      [errorCode, errorMessage] = err instanceof FetchError && (err as FetchError).cause === "timeout"
-        ? [RefreshErrorCode.HttpRequestTimeout, options.logger.fetchFailedDueToRequestTimeout((err.args as FetchErrorCauses["timeout"])[0], err)]
-        : [RefreshErrorCode.HttpRequestFailure, options.logger.fetchFailedDueToUnexpectedError(err)];
+
+      const fetchError = err instanceof FetchError ? err as FetchError : void 0;
+      if (fetchError && fetchError.cause === "timeout") {
+        errorMessage = options.logger.fetchFailedDueToRequestTimeout((fetchError.args as FetchErrorCauses["timeout"])[0], err, fetchError["rayId"]);
+        errorCode = RefreshErrorCode.HttpRequestTimeout;
+      } else {
+        errorMessage = options.logger.fetchFailedDueToUnexpectedError(err, fetchError?.["rayId"]);
+        errorCode = RefreshErrorCode.HttpRequestFailure;
+      }
 
       logMethodDebug(debugLogger, methodName, "fetch was unsuccessful. Returning null.");
       return fetchResultFromError(lastConfig, errorCode, toMessage(errorMessage), err);

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -5,7 +5,7 @@ import type { OptionsBase } from "./ConfigCatClientOptions";
 import type { LogMessage } from "./ConfigCatLogger";
 import { logMethodDebug, toMessage } from "./ConfigCatLogger";
 import type { FetchErrorCauses, FetchInternalAsyncMethod, FetchResponse, FetchResult, IConfigCatConfigFetcher } from "./ConfigFetcher";
-import { FetchError, fetchInternalAsyncMethodName, FetchRequest, fetchResultFromError, fetchResultFromNotModified, fetchResultFromSuccess, FetchStatus } from "./ConfigFetcher";
+import { CONFIGCAT_USER_AGENT_HEADER_NAME, FetchError, fetchInternalAsyncMethodName, FetchRequest, fetchResultFromError, fetchResultFromNotModified, fetchResultFromSuccess, FetchStatus, USER_AGENT_HEADER_NAME } from "./ConfigFetcher";
 import { RedirectMode } from "./ConfigJson";
 import type { Config } from "./ProjectConfig";
 import { deserializeConfig, prepareConfig, ProjectConfig } from "./ProjectConfig";
@@ -156,8 +156,8 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     this.ownsConfigFetcher = options.ownsConfigFetcher;
 
     this.requestHeaders = [
-      ["User-Agent", options.clientVersion],
-      ["X-ConfigCat-UserAgent", options.clientVersion],
+      [USER_AGENT_HEADER_NAME, options.clientVersion],
+      [CONFIGCAT_USER_AGENT_HEADER_NAME, options.clientVersion],
     ];
 
     this.status = options.offline ? ConfigServiceStatus.Offline : ConfigServiceStatus.Online;

--- a/src/FlagOverrides.ts
+++ b/src/FlagOverrides.ts
@@ -1,6 +1,6 @@
 import type { Setting, SettingValue } from "./ProjectConfig";
 import { createSettingFromValue } from "./ProjectConfig";
-import { hasOwnProperty, isArray, isString, parseFloatStrict } from "./Utils";
+import { endsWith, hasOwnProperty, isArray, isString, parseFloatStrict, startsWith } from "./Utils";
 
 export type FlagOverrides = {
   dataSource: IOverrideDataSource;
@@ -185,7 +185,7 @@ function extractSettingsFromQueryParams(queryParams: Record<string, string | Rea
 
 function extractSettingFromQueryString(queryString: string, paramPrefix: string, settings: Record<string, Setting>) {
   if (!queryString
-    || queryString.lastIndexOf("?", 0) < 0) { // identical to `!queryString.startsWith("?")`
+    || !startsWith(queryString, "?")) {
     return;
   }
 
@@ -204,14 +204,14 @@ function extractSettingFromQueryString(queryString: string, paramPrefix: string,
 function extractSettingFromQueryParam(key: string, value: string, paramPrefix: string, settings: Record<string, Setting>) {
   if (!key
     || key.length <= paramPrefix.length
-    || key.lastIndexOf(paramPrefix, 0) < 0) { // identical to `!key.startsWith(paramPrefix)`
+    || !startsWith(key, paramPrefix)) {
     return;
   }
 
   key = key.substring(paramPrefix.length);
 
   const interpretValueAsString = key.length > FORCE_STRING_VALUE_SUFFIX.length
-    && key.indexOf(FORCE_STRING_VALUE_SUFFIX, key.length - FORCE_STRING_VALUE_SUFFIX.length) >= 0; // identical to `key.endsWith(strSuffix)`
+    && endsWith(key, FORCE_STRING_VALUE_SUFFIX);
 
   if (interpretValueAsString) {
     key = key.substring(0, key.length - FORCE_STRING_VALUE_SUFFIX.length);

--- a/src/Hash.ts
+++ b/src/Hash.ts
@@ -1,4 +1,4 @@
-import { createMap, utf8Encode } from "./Utils";
+import { createMap, toHexString, utf8Encode } from "./Utils";
 
 export function sha1(msg: string) {
   function rotate_left(n: number, s: number) {
@@ -144,8 +144,8 @@ export function sha256(msgUtf8: string) {
   for (j = 0; j < words[lengthProperty];) {
     var w = words.slice(j, j += 16); // The message is expanded into 64 words as part of the iteration
     var oldHash = hash;
-    // This is now the undefinedworking hash", often labelled as variables a...g
-    // (we have to truncate as well, otherwise extra entries at the end accumulate
+    // This is now the "working hash", often labelled as variables a...g
+    // (we have to truncate as well, otherwise extra entries at the end accumulate)
     hash = hash.slice(0, 8);
 
     for (i = 0; i < 64; i++) {
@@ -181,18 +181,4 @@ export function sha256(msgUtf8: string) {
   }
 
   return toHexString(hash, 8);
-}
-
-function toHexString(int32Array: number[], count?: number) {
-  const hexDigits = "0123456789abcdef";
-  var result = "";
-  count ??= int32Array.length;
-  for (let i = 0; i < count; i++) {
-    for (let j = 3; j >= 0; j--) {
-      const b = (int32Array[i] >> (j << 3)) & 0xFF;
-      result += hexDigits[b >> 4];
-      result += hexDigits[b & 0xF];
-    } 
-  }
-  return result;
 }

--- a/src/LazyLoadConfigService.ts
+++ b/src/LazyLoadConfigService.ts
@@ -1,5 +1,5 @@
 import type { LazyLoadOptions } from "./ConfigCatClientOptions";
-import type { LoggerWrapper } from "./ConfigCatLogger";
+import { logMethodDebug } from "./ConfigCatLogger";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
@@ -22,30 +22,28 @@ export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> im
   }
 
   async getConfigAsync(): Promise<ProjectConfig> {
-    this.options.logger.debug("LazyLoadConfigService.getConfigAsync() called.");
-
-    function logExpired(logger: LoggerWrapper, appendix = "") {
-      logger.debug(`LazyLoadConfigService.getConfigAsync(): cache is empty or expired${appendix}.`);
-    }
+    const methodName = "LazyLoadConfigService.getConfigAsync";
+    const debugLogger = this.options.logger.ifDebug;
+    logMethodDebug(debugLogger, methodName);
 
     let cachedConfig = await this.syncUpWithCache();
 
     if (cachedConfig.isExpired(this.cacheTimeToLiveMs)) {
       if (!this.isOffline) {
-        logExpired(this.options.logger, ", calling refreshConfigCoreAsync()");
+        logMethodDebug(debugLogger, methodName, "cache is empty or expired, calling refreshConfigCoreAsync().");
         [, cachedConfig] = await this.refreshConfigCoreAsync(cachedConfig, false);
       } else {
-        logExpired(this.options.logger);
+        logMethodDebug(debugLogger, methodName, "cache is empty or expired.");
       }
       return cachedConfig;
     }
 
-    this.options.logger.debug("LazyLoadConfigService.getConfigAsync(): cache is valid, returning from cache.");
+    logMethodDebug(debugLogger, methodName, "cache is valid, returning from cache.");
     return cachedConfig;
   }
 
   override refreshConfigAsync(): Promise<[RefreshResult, ProjectConfig]> {
-    this.options.logger.debug("LazyLoadConfigService.refreshConfigAsync() called.");
+    logMethodDebug(this.options.logger, "LazyLoadConfigService.refreshConfigAsync");
     return super.refreshConfigAsync();
   }
 

--- a/src/ManualPollConfigService.ts
+++ b/src/ManualPollConfigService.ts
@@ -1,4 +1,5 @@
 import type { ManualPollOptions } from "./ConfigCatClientOptions";
+import { logMethodDebug } from "./ConfigCatLogger";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
@@ -26,12 +27,12 @@ export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions
   }
 
   async getConfigAsync(): Promise<ProjectConfig> {
-    this.options.logger.debug("ManualPollService.getConfigAsync() called.");
+    logMethodDebug(this.options.logger, "ManualPollService.getConfigAsync");
     return await this.syncUpWithCache();
   }
 
   override refreshConfigAsync(): Promise<[RefreshResult, ProjectConfig]> {
-    this.options.logger.debug("ManualPollService.refreshConfigAsync() called.");
+    logMethodDebug(this.options.logger, "ManualPollService.refreshConfigAsync");
     return super.refreshConfigAsync();
   }
 }

--- a/src/RolloutEvaluator.ts
+++ b/src/RolloutEvaluator.ts
@@ -10,7 +10,7 @@ import { parse as parseSemVer } from "./Semver";
 import type { IUser, UserAttributeValue, WellKnownUserObjectAttribute } from "./User";
 import { getUserAttribute, getUserAttributes, getUserIdentifier } from "./User";
 import type { Message, PickWithType } from "./Utils";
-import { ensurePrototype, errorToString, formatStringList, hasOwnProperty, isIntegerInRange, isNumber, isString, isStringArray, LazyString, parseFloatStrict, parseIntStrict, toStringSafe, utf8Encode } from "./Utils";
+import { endsWith, ensurePrototype, errorToString, formatStringList, hasOwnProperty, isIntegerInRange, isNumber, isString, isStringArray, LazyString, parseFloatStrict, parseIntStrict, startsWith, toStringSafe, utf8Encode } from "./Utils";
 
 export class EvaluateContext {
   private _settingType: SettingType | UnknownSettingType | undefined = void 0;
@@ -471,7 +471,7 @@ export class RolloutEvaluator implements IRolloutEvaluator {
     return result !== negate;
   }
 
-  private evaluateTextSliceEqualsAnyOf(text: string, comparisonValues: ReadonlyArray<string>, startsWith: boolean, negate: boolean): boolean {
+  private evaluateTextSliceEqualsAnyOf(text: string, comparisonValues: ReadonlyArray<string>, isStartsWith: boolean, negate: boolean): boolean {
     for (let i = 0; i < comparisonValues.length; i++) {
       const item = comparisonValues[i];
 
@@ -480,7 +480,7 @@ export class RolloutEvaluator implements IRolloutEvaluator {
       }
 
       // NOTE: String.prototype.startsWith/endsWith were introduced after ES5. We'd rather work around them instead of polyfilling them.
-      const result = (startsWith ? text.lastIndexOf(item, 0) : text.indexOf(item, text.length - item.length)) >= 0;
+      const result = isStartsWith ? startsWith(text, item) : endsWith(text, item);
       if (result) {
         return !negate;
       }

--- a/src/RolloutEvaluator.ts
+++ b/src/RolloutEvaluator.ts
@@ -1,5 +1,5 @@
 import type { LoggerWrapper, LogMessage } from "./ConfigCatLogger";
-import { LogLevel, toMessage } from "./ConfigCatLogger";
+import { LogLevel, logMethodDebug, toMessage } from "./ConfigCatLogger";
 import { PrerequisiteFlagComparator, SegmentComparator, SettingType, UserComparator } from "./ConfigJson";
 import { EvaluateLogBuilder, formatSegmentComparator, formatUserCondition, inferValue, valueToString } from "./EvaluateLogBuilder";
 import { sha1, sha256 } from "./Hash";
@@ -64,7 +64,7 @@ export class RolloutEvaluator implements IRolloutEvaluator {
   }
 
   evaluate(defaultValue: SettingValue, context: EvaluateContext): EvaluateResult {
-    this.logger.debug("RolloutEvaluator.evaluate() called.");
+    logMethodDebug(this.logger, "RolloutEvaluator.evaluate");
 
     // Building the evaluation log is expensive, so let's not do it if it wouldn't be logged anyway.
     const logBuilder = context.logBuilder = this.logger.isEnabled(LogLevel.Info)

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -33,6 +33,8 @@ export class AbortToken {
   }
 }
 
+/* Timing */
+
 export function delay(delayMs: number, abortToken?: AbortToken | null): Promise<boolean> {
   let timerId: ReturnType<typeof setTimeout>;
   return new Promise<boolean>(resolve => {
@@ -53,6 +55,8 @@ export const getMonotonicTimeMs = typeof performance !== "undefined" && isFuncti
   ? () => performance.now()
   : () => new Date().getTime();
 
+/* Cryptography */
+
 // eslint-disable-next-line @typescript-eslint/unbound-method
 export const randomUUID = typeof crypto !== "undefined" && isFunction(crypto?.randomUUID)
   ? () => crypto.randomUUID()
@@ -67,6 +71,8 @@ export const randomUUID = typeof crypto !== "undefined" && isFunction(crypto?.ra
     }
     return String.fromCharCode(...charCodes);
   };
+
+/* Garbage collection */
 
 // NOTE: We don't use the built-in WeakRef-related types in the signatures of the exported functions below because
 // this module is exposed via the "pubternal" API, and we don't want these types to be included in the generated
@@ -107,6 +113,28 @@ export function toStringSafe(value: unknown): string {
   }
 }
 
+/* Strings */
+
+export function indexOfAny(s: string, chars: string, position?: number): number {
+  for (let i = position == null ? 0 : Math.max(position, 0); i < s.length; i++) {
+    const ch = s.charCodeAt(i);
+    for (let j = 0; j < chars.length; j++) {
+      if (chars.charCodeAt(j) === ch) return i;
+    }
+  }
+  return -1;
+}
+
+export function startsWith(s: string, searchString: string): boolean {
+  // NOTE: String.prototype.startsWith was introduced after ES5. We'd rather work around it instead of polyfilling it.
+  return s.lastIndexOf(searchString, 0) >= 0;
+}
+
+export function endsWith(s: string, searchString: string): boolean {
+  // NOTE: String.prototype.endsWith was introduced after ES5. We'd rather work around it instead of polyfilling it.
+  return s.indexOf(searchString, s.length - searchString.length) >= 0;
+}
+
 /** Formats error in a similar way to Chromium-based browsers. */
 export function errorToString(err: any, includeStackTrace = false): string {
   return err instanceof Error ? visit(err, "") : toStringSafe(err);
@@ -117,7 +145,7 @@ export function errorToString(err: any, includeStackTrace = false): string {
     if (includeStackTrace && err.stack) {
       let stack = err.stack.trim();
       // NOTE: Some JS runtimes (e.g. V8) includes the error in the stack trace, some don't (e.g. SpiderMonkey).
-      if (stack.lastIndexOf(errString, 0) === 0) {
+      if (startsWith(stack, errString)) {
         stack = stack.substring(errString.length).trim();
       }
       s += "\n" + stack.replace(/^\s*(?:at\s)?/gm, indent + "    at ");
@@ -141,6 +169,8 @@ export function errorToString(err: any, includeStackTrace = false): string {
     return s;
   }
 }
+
+/* Objects */
 
 /** Indicates a null-prototype object that is used as a map. */
 export type ObjectMap<TKey extends keyof any, TValue> = Record<TKey, TValue>
@@ -171,6 +201,19 @@ export function ensurePrototype<T extends object>(obj: T, ctor: new (...args: an
 export function hasOwnProperty(obj: object, key: keyof any): boolean {
   return Object.prototype.hasOwnProperty.call(obj, key);
 }
+
+export function shallowClone<T extends {}>(obj: T, propertyReplacer?: (key: keyof T, value: unknown) => unknown): Record<keyof T, unknown> {
+  const clone = {} as Record<keyof T, unknown>;
+  for (const key in obj) {
+    if (hasOwnProperty(obj, key)) {
+      const value = obj[key];
+      clone[key] = propertyReplacer ? propertyReplacer(key, value) : value;
+    }
+  }
+  return clone;
+}
+
+/* Data validation */
 
 export function isBoolean(value: unknown): value is boolean {
   return typeof value === "boolean";
@@ -281,6 +324,8 @@ export function throwInvalidArg(argName: string, reason: string, memberPath?: st
   throw (errorConstructor ?? Error)(`Invalid ${argKind} \`${argName}${memberPath}\`. ${reason}`);
 }
 
+/* Data formatting */
+
 export function formatStringList(items: ReadonlyArray<string>, maxLength = 0, getOmittedItemsText?: (count: number) => string, separator = ", "): string {
   const length = items.length;
   if (!length) {
@@ -357,6 +402,8 @@ export function toHexString(int32Array: number[], count?: number): string {
   return result;
 }
 
+/* Data parsing */
+
 export function parseIntStrict(value: string): number {
   // NOTE: JS's int to string conversion (parseInt) is too forgiving, it accepts hex numbers and ignores invalid characters after the number.
 
@@ -378,16 +425,7 @@ export function parseFloatStrict(value: string): number {
   return +value;
 }
 
-export function shallowClone<T extends {}>(obj: T, propertyReplacer?: (key: keyof T, value: unknown) => unknown): Record<keyof T, unknown> {
-  const clone = {} as Record<keyof T, unknown>;
-  for (const key in obj) {
-    if (hasOwnProperty(obj, key)) {
-      const value = obj[key];
-      clone[key] = propertyReplacer ? propertyReplacer(key, value) : value;
-    }
-  }
-  return clone;
-}
+/* Messages */
 
 export class LazyString<TState = any> {
   private factoryOrValue: ((state: TState) => string) | string;
@@ -407,6 +445,8 @@ export class LazyString<TState = any> {
 }
 
 export type Message = { toString(): string };
+
+/* Utility types */
 
 /** Picks a set of properties from object `T` and change their type as specified by `TPropMap`. */
 export type PickWithType<T, TPropMap extends { [K in keyof T]?: unknown }> = {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,3 +1,5 @@
+const hexDigits = "0123456789abcdef";
+
 // NOTE: Normally, we'd just use AbortController/AbortSignal, however that may not be available on all platforms,
 // and we don't want to include a complete polyfill. So we implement a simplified version that fits our use case.
 export class AbortToken {
@@ -50,6 +52,21 @@ export function delay(delayMs: number, abortToken?: AbortToken | null): Promise<
 export const getMonotonicTimeMs = typeof performance !== "undefined" && isFunction(performance?.now)
   ? () => performance.now()
   : () => new Date().getTime();
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+export const randomUUID = typeof crypto !== "undefined" && isFunction(crypto?.randomUUID)
+  ? () => crypto.randomUUID()
+  : () => {
+    const charCodes = new Array(36) as number[];
+    for (let i = 0; i < charCodes.length; i++) {
+      let r: number;
+      charCodes[i] =
+        i === 8 || i === 13 || i === 18 || i === 23 ? 0x2d // '-'
+        : i === 14 ? 0x34 // '4'
+        : (r = Math.random() * 16 | 0, hexDigits.charCodeAt(i === 19 ? r & 0x3 | 0x8 : r));
+    }
+    return String.fromCharCode(...charCodes);
+  };
 
 // NOTE: We don't use the built-in WeakRef-related types in the signatures of the exported functions below because
 // this module is exposed via the "pubternal" API, and we don't want these types to be included in the generated
@@ -325,6 +342,19 @@ export function utf8Encode(text: string): string {
   }
 
   return utf8text += text.slice(chunkStart, i);
+}
+
+export function toHexString(int32Array: number[], count?: number): string {
+  let result = "";
+  count ??= int32Array.length;
+  for (let i = 0; i < count; i++) {
+    for (let j = 3; j >= 0; j--) {
+      const b = (int32Array[i] >> (j << 3)) & 0xFF;
+      result += hexDigits[b >> 4];
+      result += hexDigits[b & 0xF];
+    }
+  }
+  return result;
 }
 
 export function parseIntStrict(value: string): number {

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -2,7 +2,7 @@ import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, FetchResponse } from "../ConfigFetcher";
+import { FetchError, fetchInternalAsyncMethodName, FetchResponse } from "../ConfigFetcher";
 
 interface IHttpRequest {
   setRequestHeader(name: string, value: string): void;
@@ -10,14 +10,8 @@ interface IHttpRequest {
 
 export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   private static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
-    return options => {
-      const configFetcher = new XmlHttpRequestConfigFetcher();
-      configFetcher.logger = options.logger;
-      return configFetcher;
-    };
+    return () => new XmlHttpRequestConfigFetcher();
   }
-
-  private logger: LoggerWrapper | null = null;
 
   private handleStateChange(httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
     try {
@@ -38,9 +32,13 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   }
 
   fetchAsync(request: FetchRequest): Promise<FetchResponse> {
+    return this[fetchInternalAsyncMethodName](request);
+  }
+
+  private [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
       try {
-        this.logger?.debug("XmlHttpRequestConfigFetcher.fetchAsync() called.");
+        logger?.debug("XmlHttpRequestConfigFetcher.fetchAsync() called.");
 
         let { url } = request;
         const isCustomUrl = !isCdnUrl(url);

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -37,37 +37,32 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 
   private [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
-      try {
-        logger?.debug("XmlHttpRequestConfigFetcher.fetchAsync() called.");
+      logger?.debug("XmlHttpRequestConfigFetcher.fetchAsync() called.");
 
-        let { url } = request;
-        const isCustomUrl = !isCdnUrl(url);
-        const { lastETag, timeoutMs } = request;
+      let { url } = request;
+      const isCustomUrl = !isCdnUrl(url);
+      const { lastETag, timeoutMs } = request;
 
-        if (lastETag) {
-          // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header,
-          // we can transform this query param to the header in our CDN provider.
-          // (Explicitly specifying the If-None-Match header would cause an unnecessary CORS OPTIONS request.)
-          url += "&ccetag=" + encodeURIComponent(lastETag);
-        }
-
-        const httpRequest: XMLHttpRequest = new XMLHttpRequest();
-
-        httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject);
-        httpRequest.ontimeout = () => reject(new FetchError("timeout", timeoutMs));
-        httpRequest.onabort = () => reject(new FetchError("abort"));
-        httpRequest.onerror = () => reject(new FetchError("failure"));
-
-        httpRequest.open("GET", url, true);
-        httpRequest.timeout = timeoutMs;
-        if (isCustomUrl) {
-          this.setRequestHeaders(httpRequest, request.headers);
-        }
-        httpRequest.send(null);
-      } catch (err) {
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        reject(err);
+      if (lastETag) {
+        // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header,
+        // we can transform this query param to the header in our CDN provider.
+        // (Explicitly specifying the If-None-Match header would cause an unnecessary CORS OPTIONS request.)
+        url += "&ccetag=" + encodeURIComponent(lastETag);
       }
+
+      const httpRequest: XMLHttpRequest = new XMLHttpRequest();
+
+      httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject);
+      httpRequest.ontimeout = () => reject(new FetchError("timeout", timeoutMs));
+      httpRequest.onabort = () => reject(new FetchError("abort"));
+      httpRequest.onerror = () => reject(new FetchError("failure"));
+
+      httpRequest.open("GET", url, true);
+      httpRequest.timeout = timeoutMs;
+      if (isCustomUrl) {
+        this.setRequestHeaders(httpRequest, request.headers);
+      }
+      httpRequest.send(null);
     });
   }
 

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -1,7 +1,7 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
-import type { FetchInternalAsyncMethodType, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
 import { delay } from "../Utils";
 
@@ -37,7 +37,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   }
 
   // Defined directly on the prototype, see below.
-  private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethodType<XmlHttpRequestConfigFetcher>;
+  private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethod<XmlHttpRequestConfigFetcher>;
 
   private fetchCoreAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -1,8 +1,9 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
-import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, fetchInternalAsyncMethodName, FetchResponse } from "../ConfigFetcher";
+import type { FetchInternalAsyncMethodType, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
+import { delay } from "../Utils";
 
 interface IHttpRequest {
   setRequestHeader(name: string, value: string): void;
@@ -35,10 +36,11 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     return this[fetchInternalAsyncMethodName](request);
   }
 
-  private [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
-    return new Promise<FetchResponse>((resolve, reject) => {
-      logger?.debug("XmlHttpRequestConfigFetcher.fetchAsync() called.");
+  // Defined directly on the prototype, see below.
+  private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethodType<XmlHttpRequestConfigFetcher>;
 
+  private fetchCoreAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
+    return new Promise<FetchResponse>((resolve, reject) => {
       let { url } = request;
       const isCustomUrl = !isCdnUrl(url);
       const { lastETag, timeoutMs } = request;
@@ -69,6 +71,27 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   protected setRequestHeaders(httpRequest: IHttpRequest, headers: ReadonlyArray<readonly [string, string]>): void {
   }
 }
+
+XmlHttpRequestConfigFetcher.prototype[fetchInternalAsyncMethodName] = async function(request: FetchRequest, logger?: LoggerWrapper) {
+  logger?.debug("XmlHttpRequestConfigFetcher.fetchAsync() called.");
+
+  for (let retryNumber = 0; ; retryNumber++) {
+    try {
+      const fetchResponse = await this["fetchCoreAsync"](request, logger);
+      if (FetchResponse.prototype.isExpected.call(fetchResponse) || retryNumber >= fetchRetryLimit) {
+        return fetchResponse;
+      }
+    } catch (err) {
+      if (retryNumber >= fetchRetryLimit
+            || !(err instanceof FetchError)
+            || (err as FetchError).cause !== "timeout" && (err as FetchError).cause !== "failure") {
+        throw err;
+      }
+    }
+
+    await delay(fetchRetryDelayMs);
+  }
+};
 
 function getResponseHeadersDefault(httpRequest: XMLHttpRequest): [string, string][] {
   const headers: [string, string][] = [];

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -4,7 +4,7 @@ import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { adjustUrlForBrowser, FETCH_RETRY_DELAY_MS, FETCH_RETRY_LIMIT, FetchError, fetchInternalAsyncMethodName, FetchResponse, REQUEST_ID_ARG_NAME } from "../ConfigFetcher";
-import { delay, randomUUID } from "../Utils";
+import { AbortToken, delay, randomUUID } from "../Utils";
 
 interface IHttpRequest {
   setRequestHeader(name: string, value: string): void;
@@ -21,10 +21,10 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     return () => new XmlHttpRequestConfigFetcher();
   }
 
-  private isDisposed = false;
+  private readonly disposeToken = new AbortToken();
 
   dispose(): void {
-    this.isDisposed = true;
+    this.disposeToken.abort();
   }
 
   private handleStateChange(
@@ -90,7 +90,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     const isCustomUrl = !isCdnUrl(request.url);
 
     for (let retryNumber = 0; ; retryNumber++) {
-      if (this.isDisposed) {
+      if (this.disposeToken.aborted) {
         throw new FetchError("abort");
       }
 
@@ -137,6 +137,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   }
 
   private fetchCoreAsync(request: FetchRequest, isCustomUrl: boolean, context: FetchContext): Promise<FetchResponse> {
+    let unregisterFromDisposeToken: (() => void) | undefined;
     return new Promise<FetchResponse>((resolve, reject) => {
       const { debugLogger, requestId } = context;
       let { url } = request;
@@ -144,6 +145,8 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 
       url = adjustUrlForBrowser(request.url, request);
       const httpRequest: XMLHttpRequest = new XMLHttpRequest();
+
+      unregisterFromDisposeToken = this.disposeToken.registerCallback(() => httpRequest.abort());
 
       httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject, context);
       httpRequest.ontimeout = () => reject(new (FetchError as FetchErrorCtorInternal)("timeout", timeoutMs, context.fetchResponse?.["rayId"]));
@@ -161,7 +164,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
       )`[${requestId}] Sending request... (Url: '${url}')`);
 
       httpRequest.send(null);
-    });
+    }).finally(() => unregisterFromDisposeToken?.());
   }
 
   protected setRequestHeaders(httpRequest: IHttpRequest, headers: ReadonlyArray<readonly [string, string]>): void {

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -91,7 +91,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 
     for (let retryNumber = 0; ; retryNumber++) {
       if (this.isDisposed) {
-        throw retryNumber > 0 ? new FetchError("abort") : Error(`${this.constructor.name} object has been disposed.`);
+        throw new FetchError("abort");
       }
 
       try {

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -3,7 +3,7 @@ import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit, requestIdArgName } from "../ConfigFetcher";
+import { adjustUrlForBrowser, FETCH_RETRY_DELAY_MS, FETCH_RETRY_LIMIT, FetchError, fetchInternalAsyncMethodName, FetchResponse, REQUEST_ID_ARG_NAME } from "../ConfigFetcher";
 import { delay, randomUUID } from "../Utils";
 
 interface IHttpRequest {
@@ -39,7 +39,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
         if (debugLogger) {
           const eTagHeaderValue = httpRequest.getResponseHeader("ETag");
           debugLogger.debug(FormattableLogMessage.from(
-            requestIdArgName, "STATUS_CODE", "REASON_PHRASE", "ETAG"
+            REQUEST_ID_ARG_NAME, "STATUS_CODE", "REASON_PHRASE", "ETAG"
           )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
         }
 
@@ -58,7 +58,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
             const body = (fetchResponse as { body: string }).body = httpRequest.responseText;
 
             debugLogger?.debug(FormattableLogMessage.from(
-              requestIdArgName, "LENGTH"
+              REQUEST_ID_ARG_NAME, "LENGTH"
             )`[${requestId}] Received body. (Length: ${body.length})`);
           }
 
@@ -84,7 +84,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     if (debugLogger) {
       requestId = randomUUID();
 
-      debugLogger.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Preparing request...`);
+      debugLogger.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Preparing request...`);
     }
 
     const isCustomUrl = !isCdnUrl(request.url);
@@ -102,37 +102,37 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
           return fetchResponse;
         }
 
-        debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Received unexpected status code.`);
+        debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Received unexpected status code.`);
 
-        if (retryNumber >= fetchRetryLimit) {
+        if (retryNumber >= FETCH_RETRY_LIMIT) {
           return fetchResponse;
         }
       } catch (err) {
         if (err instanceof FetchError) {
           switch ((err as FetchError).cause) {
             case "abort":
-              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request aborted.`);
+              debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request aborted.`);
               throw err;
             case "timeout":
-              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request timed out.`);
+              debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request timed out.`);
               break;
             case "failure":
-              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request failed.`);
+              debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request failed.`);
               break;
           }
         } else {
           throw err;
         }
 
-        if (retryNumber >= fetchRetryLimit) {
+        if (retryNumber >= FETCH_RETRY_LIMIT) {
           throw err;
         }
       }
 
       // Wait a little before trying again.
-      await delay(fetchRetryDelayMs);
+      await delay(FETCH_RETRY_DELAY_MS);
 
-      debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Trying request again...`);
+      debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Trying request again...`);
     }
   }
 
@@ -140,15 +140,9 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     return new Promise<FetchResponse>((resolve, reject) => {
       const { debugLogger, requestId } = context;
       let { url } = request;
-      const { lastETag, timeoutMs } = request;
+      const { timeoutMs } = request;
 
-      if (lastETag) {
-        // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header,
-        // we can transform this query param to the header in our CDN provider.
-        // (Explicitly specifying the If-None-Match header would cause an unnecessary CORS OPTIONS request.)
-        url += "&ccetag=" + encodeURIComponent(lastETag);
-      }
-
+      url = adjustUrlForBrowser(request.url, request);
       const httpRequest: XMLHttpRequest = new XMLHttpRequest();
 
       httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject, context);
@@ -163,7 +157,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       debugLogger?.debug(FormattableLogMessage.from(
-        requestIdArgName, "URL"
+        REQUEST_ID_ARG_NAME, "URL"
       )`[${requestId}] Sending request... (Url: '${url}')`);
 
       httpRequest.send(null);

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -1,10 +1,10 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
-import { logMethodDebug } from "../ConfigCatLogger";
+import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
-import { delay } from "../Utils";
+import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit, requestIdArgName } from "../ConfigFetcher";
+import { delay, randomUUID } from "../Utils";
 
 interface IHttpRequest {
   setRequestHeader(name: string, value: string): void;
@@ -21,16 +21,34 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     this.isDisposed = true;
   }
 
-  private handleStateChange(httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
+  private handleStateChange(
+    httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void,
+    requestId: string | undefined, debugLogger: LoggerWrapper | undefined
+  ) {
     try {
-      if (httpRequest.readyState === 4) {
+      if (httpRequest.readyState === 2) {
+        if (debugLogger) {
+          const { status: statusCode, statusText: reasonPhrase } = httpRequest;
+          const eTagHeaderValue = httpRequest.getResponseHeader("ETag");
+          debugLogger.debug(FormattableLogMessage.from(
+            requestIdArgName, "STATUS_CODE", "REASON_PHRASE", "ETAG"
+          )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
+        }
+      } else if (httpRequest.readyState === 4) {
         const { status: statusCode, statusText: reasonPhrase } = httpRequest;
 
         // The readystatechange event is emitted even in the case of abort or error.
         // We can detect this by checking for zero status code (see https://stackoverflow.com/a/19247992/8656352).
         if (statusCode) {
           const headers = getResponseHeadersDefault(httpRequest);
-          const body = statusCode === 200 ? httpRequest.responseText : void 0;
+          let body: string | undefined;
+          if (statusCode === 200) {
+            body = httpRequest.responseText;
+
+            debugLogger?.debug(FormattableLogMessage.from(
+              requestIdArgName, "LENGTH"
+            )`[${requestId}] Received body. (Length: ${body.length})`);
+          }
           resolve(new FetchResponse(statusCode, reasonPhrase, headers, body));
         }
       }
@@ -46,7 +64,16 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   // Defined directly on the prototype, see below.
   private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethod<XmlHttpRequestConfigFetcher>;
 
-  private async fetchWithRetryAsync(request: FetchRequest, logger?: LoggerWrapper) {
+  private async fetchWithRetryAsync(request: FetchRequest, logger: LoggerWrapper | undefined) {
+    const debugLogger = logger?.ifDebug;
+    let requestId: string | undefined;
+
+    if (debugLogger) {
+      requestId = randomUUID();
+
+      debugLogger.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Preparing request...`);
+    }
+
     const isCustomUrl = !isCdnUrl(request.url);
 
     for (let retryNumber = 0; ; retryNumber++) {
@@ -55,24 +82,50 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       try {
-        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, logger);
-        if (FetchResponse.prototype.isExpected.call(fetchResponse) || retryNumber >= fetchRetryLimit) {
+        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, requestId, debugLogger);
+
+        if (FetchResponse.prototype.isExpected.call(fetchResponse)) {
+          return fetchResponse;
+        }
+
+        debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Received unexpected status code.`);
+
+        if (retryNumber >= fetchRetryLimit) {
           return fetchResponse;
         }
       } catch (err) {
-        if (retryNumber >= fetchRetryLimit
-            || !(err instanceof FetchError)
-            || (err as FetchError).cause !== "timeout" && (err as FetchError).cause !== "failure") {
+        if (err instanceof FetchError) {
+          switch ((err as FetchError).cause) {
+            case "abort":
+              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request aborted.`);
+              throw err;
+            case "timeout":
+              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request timed out.`);
+              break;
+            case "failure":
+              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request failed.`);
+              break;
+          }
+        } else {
+          throw err;
+        }
+
+        if (retryNumber >= fetchRetryLimit) {
           throw err;
         }
       }
 
       // Wait a little before trying again.
       await delay(fetchRetryDelayMs);
+
+      debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Trying request again...`);
     }
   }
 
-  private fetchCoreAsync(request: FetchRequest, isCustomUrl: boolean, logger?: LoggerWrapper): Promise<FetchResponse> {
+  private fetchCoreAsync(
+    request: FetchRequest, isCustomUrl: boolean,
+    requestId: string | undefined, debugLogger: LoggerWrapper | undefined
+  ): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
       let { url } = request;
       const { lastETag, timeoutMs } = request;
@@ -86,7 +139,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 
       const httpRequest: XMLHttpRequest = new XMLHttpRequest();
 
-      httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject);
+      httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject, requestId, debugLogger);
       httpRequest.ontimeout = () => reject(new FetchError("timeout", timeoutMs));
       httpRequest.onabort = () => reject(new FetchError("abort"));
       httpRequest.onerror = () => reject(new FetchError("failure"));
@@ -96,6 +149,11 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
       if (isCustomUrl) {
         this.setRequestHeaders(httpRequest, request.headers);
       }
+
+      debugLogger?.debug(FormattableLogMessage.from(
+        requestIdArgName, "URL"
+      )`[${requestId}] Sending request... (Url: '${url}')`);
+
       httpRequest.send(null);
     });
   }

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -1,6 +1,7 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
+import { logMethodDebug } from "../ConfigCatLogger";
 import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
 import { delay } from "../Utils";
@@ -104,8 +105,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 }
 
 XmlHttpRequestConfigFetcher.prototype[fetchInternalAsyncMethodName] = function(request: FetchRequest, logger?: LoggerWrapper) {
-  logger?.debug("XmlHttpRequestConfigFetcher.fetchAsync() called.");
-
+  logMethodDebug(logger, "XmlHttpRequestConfigFetcher.fetchAsync");
   return this["fetchWithRetryAsync"](request, logger);
 };
 

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -30,49 +30,6 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     this.disposeToken.abort();
   }
 
-  private handleStateChange(
-    httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void, context: FetchContext
-  ) {
-    try {
-      const { debugLogger, requestId } = context;
-
-      if (httpRequest.readyState === 2) {
-        const { status: statusCode, statusText: reasonPhrase } = httpRequest;
-
-        if (debugLogger) {
-          const eTagHeaderValue = httpRequest.getResponseHeader("ETag");
-          debugLogger.debug(FormattableLogMessage.from(
-            REQUEST_ID_ARG_NAME, "STATUS_CODE", "REASON_PHRASE", "ETAG"
-          )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
-        }
-
-        const headers = getResponseHeadersDefault(httpRequest);
-        context.fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers);
-      } else if (httpRequest.readyState === 4) {
-        const { status: statusCode, statusText: reasonPhrase } = httpRequest;
-
-        // The readystatechange event is emitted even in the case of abort or error.
-        // We can detect this by checking for zero status code (see https://stackoverflow.com/a/19247992/8656352).
-        if (statusCode) {
-          const fetchResponse = context.fetchResponse
-            ?? new FetchResponse(statusCode, reasonPhrase, getResponseHeadersDefault(httpRequest)); // just in case
-
-          if (statusCode === 200) {
-            const body = (fetchResponse as { body: string }).body = httpRequest.responseText;
-
-            debugLogger?.debug(FormattableLogMessage.from(
-              REQUEST_ID_ARG_NAME, "LENGTH"
-            )`[${requestId}] Received body. (Length: ${body.length})`);
-          }
-
-          resolve(fetchResponse);
-        }
-      }
-    } catch (err) {
-      reject(err);
-    }
-  }
-
   fetchAsync(request: FetchRequest): Promise<FetchResponse> {
     return this[fetchInternalAsyncMethodName](request);
   }
@@ -170,6 +127,49 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 
       httpRequest.send(null);
     }).finally(() => unregisterFromDisposeToken?.());
+  }
+
+  private handleStateChange(
+    httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void, context: FetchContext
+  ) {
+    try {
+      const { debugLogger, requestId } = context;
+
+      if (httpRequest.readyState === 2) {
+        const { status: statusCode, statusText: reasonPhrase } = httpRequest;
+
+        if (debugLogger) {
+          const eTagHeaderValue = httpRequest.getResponseHeader("ETag");
+          debugLogger.debug(FormattableLogMessage.from(
+            REQUEST_ID_ARG_NAME, "STATUS_CODE", "REASON_PHRASE", "ETAG"
+          )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
+        }
+
+        const headers = getResponseHeadersDefault(httpRequest);
+        context.fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers);
+      } else if (httpRequest.readyState === 4) {
+        const { status: statusCode, statusText: reasonPhrase } = httpRequest;
+
+        // The readystatechange event is emitted even in the case of abort or error.
+        // We can detect this by checking for zero status code (see https://stackoverflow.com/a/19247992/8656352).
+        if (statusCode) {
+          const fetchResponse = context.fetchResponse
+            ?? new FetchResponse(statusCode, reasonPhrase, getResponseHeadersDefault(httpRequest)); // just in case
+
+          if (statusCode === 200) {
+            const body = (fetchResponse as { body: string }).body = httpRequest.responseText;
+
+            debugLogger?.debug(FormattableLogMessage.from(
+              REQUEST_ID_ARG_NAME, "LENGTH"
+            )`[${requestId}] Received body. (Length: ${body.length})`);
+          }
+
+          resolve(fetchResponse);
+        }
+      }
+    } catch (err) {
+      reject(err);
+    }
   }
 
   protected setRequestHeaders(httpRequest: IHttpRequest, headers: ReadonlyArray<readonly [string, string]>): void {

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -111,7 +111,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
       unregisterFromDisposeToken = this.disposeToken.registerCallback(() => httpRequest.abort());
 
       httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject, context);
-      httpRequest.ontimeout = function() { reject(new (FetchError as FetchErrorCtorInternal)("timeout", this.timeout, context.fetchResponse?.["rayId"])); };
+      httpRequest.ontimeout = () => reject(new (FetchError as FetchErrorCtorInternal)("timeout", httpRequest.timeout, context.fetchResponse?.["rayId"]));
       httpRequest.onabort = () => reject(new (FetchError as FetchErrorCtorInternal)("abort", context.fetchResponse?.["rayId"]));
       httpRequest.onerror = () => reject(new (FetchError as FetchErrorCtorInternal)("failure", void 0, context.fetchResponse?.["rayId"]));
 

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -14,6 +14,12 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     return () => new XmlHttpRequestConfigFetcher();
   }
 
+  private isDisposed = false;
+
+  dispose(): void {
+    this.isDisposed = true;
+  }
+
   private handleStateChange(httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
     try {
       if (httpRequest.readyState === 4) {
@@ -39,10 +45,35 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   // Defined directly on the prototype, see below.
   private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethod<XmlHttpRequestConfigFetcher>;
 
-  private fetchCoreAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
+  private async fetchWithRetryAsync(request: FetchRequest, logger?: LoggerWrapper) {
+    const isCustomUrl = !isCdnUrl(request.url);
+
+    for (let retryNumber = 0; ; retryNumber++) {
+      if (this.isDisposed) {
+        throw retryNumber > 0 ? new FetchError("abort") : Error(`${this.constructor.name} object has been disposed.`);
+      }
+
+      try {
+        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, logger);
+        if (FetchResponse.prototype.isExpected.call(fetchResponse) || retryNumber >= fetchRetryLimit) {
+          return fetchResponse;
+        }
+      } catch (err) {
+        if (retryNumber >= fetchRetryLimit
+            || !(err instanceof FetchError)
+            || (err as FetchError).cause !== "timeout" && (err as FetchError).cause !== "failure") {
+          throw err;
+        }
+      }
+
+      // Wait a little before trying again.
+      await delay(fetchRetryDelayMs);
+    }
+  }
+
+  private fetchCoreAsync(request: FetchRequest, isCustomUrl: boolean, logger?: LoggerWrapper): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
       let { url } = request;
-      const isCustomUrl = !isCdnUrl(url);
       const { lastETag, timeoutMs } = request;
 
       if (lastETag) {
@@ -72,25 +103,10 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   }
 }
 
-XmlHttpRequestConfigFetcher.prototype[fetchInternalAsyncMethodName] = async function(request: FetchRequest, logger?: LoggerWrapper) {
+XmlHttpRequestConfigFetcher.prototype[fetchInternalAsyncMethodName] = function(request: FetchRequest, logger?: LoggerWrapper) {
   logger?.debug("XmlHttpRequestConfigFetcher.fetchAsync() called.");
 
-  for (let retryNumber = 0; ; retryNumber++) {
-    try {
-      const fetchResponse = await this["fetchCoreAsync"](request, logger);
-      if (FetchResponse.prototype.isExpected.call(fetchResponse) || retryNumber >= fetchRetryLimit) {
-        return fetchResponse;
-      }
-    } catch (err) {
-      if (retryNumber >= fetchRetryLimit
-            || !(err instanceof FetchError)
-            || (err as FetchError).cause !== "timeout" && (err as FetchError).cause !== "failure") {
-        throw err;
-      }
-    }
-
-    await delay(fetchRetryDelayMs);
-  }
+  return this["fetchWithRetryAsync"](request, logger);
 };
 
 function getResponseHeadersDefault(httpRequest: XMLHttpRequest): [string, string][] {

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -2,13 +2,19 @@ import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
-import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit, requestIdArgName } from "../ConfigFetcher";
 import { delay, randomUUID } from "../Utils";
 
 interface IHttpRequest {
   setRequestHeader(name: string, value: string): void;
 }
+
+type FetchContext = {
+  readonly debugLogger: LoggerWrapper | undefined;
+  readonly requestId: string | undefined;
+  fetchResponse: FetchResponse | undefined;
+};
 
 export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   private static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
@@ -22,34 +28,41 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
   }
 
   private handleStateChange(
-    httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void,
-    requestId: string | undefined, debugLogger: LoggerWrapper | undefined
+    httpRequest: XMLHttpRequest, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void, context: FetchContext
   ) {
     try {
+      const { debugLogger, requestId } = context;
+
       if (httpRequest.readyState === 2) {
+        const { status: statusCode, statusText: reasonPhrase } = httpRequest;
+
         if (debugLogger) {
-          const { status: statusCode, statusText: reasonPhrase } = httpRequest;
           const eTagHeaderValue = httpRequest.getResponseHeader("ETag");
           debugLogger.debug(FormattableLogMessage.from(
             requestIdArgName, "STATUS_CODE", "REASON_PHRASE", "ETAG"
           )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
         }
+
+        const headers = getResponseHeadersDefault(httpRequest);
+        context.fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers);
       } else if (httpRequest.readyState === 4) {
         const { status: statusCode, statusText: reasonPhrase } = httpRequest;
 
         // The readystatechange event is emitted even in the case of abort or error.
         // We can detect this by checking for zero status code (see https://stackoverflow.com/a/19247992/8656352).
         if (statusCode) {
-          const headers = getResponseHeadersDefault(httpRequest);
-          let body: string | undefined;
+          const fetchResponse = context.fetchResponse
+            ?? new FetchResponse(statusCode, reasonPhrase, getResponseHeadersDefault(httpRequest)); // just in case
+
           if (statusCode === 200) {
-            body = httpRequest.responseText;
+            const body = (fetchResponse as { body: string }).body = httpRequest.responseText;
 
             debugLogger?.debug(FormattableLogMessage.from(
               requestIdArgName, "LENGTH"
             )`[${requestId}] Received body. (Length: ${body.length})`);
           }
-          resolve(new FetchResponse(statusCode, reasonPhrase, headers, body));
+
+          resolve(fetchResponse);
         }
       }
     } catch (err) {
@@ -82,7 +95,8 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       try {
-        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, requestId, debugLogger);
+        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl,
+          { debugLogger, requestId, fetchResponse: void 0 });
 
         if (FetchResponse.prototype.isExpected.call(fetchResponse)) {
           return fetchResponse;
@@ -122,11 +136,9 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     }
   }
 
-  private fetchCoreAsync(
-    request: FetchRequest, isCustomUrl: boolean,
-    requestId: string | undefined, debugLogger: LoggerWrapper | undefined
-  ): Promise<FetchResponse> {
+  private fetchCoreAsync(request: FetchRequest, isCustomUrl: boolean, context: FetchContext): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
+      const { debugLogger, requestId } = context;
       let { url } = request;
       const { lastETag, timeoutMs } = request;
 
@@ -139,10 +151,10 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 
       const httpRequest: XMLHttpRequest = new XMLHttpRequest();
 
-      httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject, requestId, debugLogger);
-      httpRequest.ontimeout = () => reject(new FetchError("timeout", timeoutMs));
-      httpRequest.onabort = () => reject(new FetchError("abort"));
-      httpRequest.onerror = () => reject(new FetchError("failure"));
+      httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject, context);
+      httpRequest.ontimeout = () => reject(new (FetchError as FetchErrorCtorInternal)("timeout", timeoutMs, context.fetchResponse?.["rayId"]));
+      httpRequest.onabort = () => reject(new (FetchError as FetchErrorCtorInternal)("abort", context.fetchResponse?.["rayId"]));
+      httpRequest.onerror = () => reject(new (FetchError as FetchErrorCtorInternal)("failure", void 0, context.fetchResponse?.["rayId"]));
 
       httpRequest.open("GET", url, true);
       httpRequest.timeout = timeoutMs;

--- a/src/browser/XmlHttpRequestConfigFetcher.ts
+++ b/src/browser/XmlHttpRequestConfigFetcher.ts
@@ -21,6 +21,9 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
     return () => new XmlHttpRequestConfigFetcher();
   }
 
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly
+  private requestRetryDelayMs = FETCH_RETRY_DELAY_MS;
+
   private readonly disposeToken = new AbortToken();
 
   dispose(): void {
@@ -83,11 +86,14 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
 
     if (debugLogger) {
       requestId = randomUUID();
-
       debugLogger.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Preparing request...`);
     }
 
+    let { url } = request;
     const isCustomUrl = !isCdnUrl(request.url);
+    const { headers, timeoutMs } = request;
+
+    url = adjustUrlForBrowser(url, request);
 
     for (let retryNumber = 0; ; retryNumber++) {
       if (this.disposeToken.aborted) {
@@ -95,7 +101,7 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       try {
-        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl,
+        const fetchResponse = await this.fetchCoreAsync(url, isCustomUrl ? headers : void 0, timeoutMs,
           { debugLogger, requestId, fetchResponse: void 0 });
 
         if (FetchResponse.prototype.isExpected.call(fetchResponse)) {
@@ -130,33 +136,32 @@ export class XmlHttpRequestConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       // Wait a little before trying again.
-      await delay(FETCH_RETRY_DELAY_MS);
+      await delay(this.requestRetryDelayMs);
 
       debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Trying request again...`);
     }
   }
 
-  private fetchCoreAsync(request: FetchRequest, isCustomUrl: boolean, context: FetchContext): Promise<FetchResponse> {
+  private fetchCoreAsync(
+    url: string, headers: ReadonlyArray<readonly [name: string, value: string]> | undefined, timeoutMs: number, context: FetchContext
+  ): Promise<FetchResponse> {
     let unregisterFromDisposeToken: (() => void) | undefined;
     return new Promise<FetchResponse>((resolve, reject) => {
       const { debugLogger, requestId } = context;
-      let { url } = request;
-      const { timeoutMs } = request;
 
-      url = adjustUrlForBrowser(request.url, request);
       const httpRequest: XMLHttpRequest = new XMLHttpRequest();
 
       unregisterFromDisposeToken = this.disposeToken.registerCallback(() => httpRequest.abort());
 
       httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject, context);
-      httpRequest.ontimeout = () => reject(new (FetchError as FetchErrorCtorInternal)("timeout", timeoutMs, context.fetchResponse?.["rayId"]));
+      httpRequest.ontimeout = function() { reject(new (FetchError as FetchErrorCtorInternal)("timeout", this.timeout, context.fetchResponse?.["rayId"])); };
       httpRequest.onabort = () => reject(new (FetchError as FetchErrorCtorInternal)("abort", context.fetchResponse?.["rayId"]));
       httpRequest.onerror = () => reject(new (FetchError as FetchErrorCtorInternal)("failure", void 0, context.fetchResponse?.["rayId"]));
 
       httpRequest.open("GET", url, true);
       httpRequest.timeout = timeoutMs;
-      if (isCustomUrl) {
-        this.setRequestHeaders(httpRequest, request.headers);
+      if (headers) {
+        this.setRequestHeaders(httpRequest, headers);
       }
 
       debugLogger?.debug(FormattableLogMessage.from(

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -94,50 +94,45 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
 
   private [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
-      try {
-        logger?.debug("NodeHttpConfigFetcher.fetchAsync() called.");
+      logger?.debug("NodeHttpConfigFetcher.fetchAsync() called.");
 
-        const { url } = request;
-        const isCustomUrl = !isCdnUrl(url);
-        const isHttpsUrl = url.startsWith("https:");
+      const { url } = request;
+      const isCustomUrl = !isCdnUrl(url);
+      const isHttpsUrl = url.startsWith("https:");
 
-        const { lastETag, timeoutMs } = request;
+      const { lastETag, timeoutMs } = request;
 
-        const requestOptions = Object.create(null) as (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> };
-        requestOptions.agent = isHttpsUrl ? this.httpsAgent : this.httpAgent;
-        requestOptions.timeout = timeoutMs;
+      const requestOptions = Object.create(null) as (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> };
+      requestOptions.agent = isHttpsUrl ? this.httpsAgent : this.httpAgent;
+      requestOptions.timeout = timeoutMs;
 
-        if (isCustomUrl) {
-          this.setRequestHeaders(requestOptions, request.headers);
-        } else {
-          setRequestHeadersDefault(requestOptions, request.headers);
-        }
-
-        if (lastETag) {
-          (requestOptions.headers ??= {})["If-None-Match"] = lastETag;
-        }
-
-        if (logger?.isEnabled(LogLevel.Debug)) {
-          const requestOptionsSafe = JSON.stringify({ ...requestOptions, agent: toStringSafe(requestOptions.agent) });
-          logger.debug(FormattableLogMessage.from("OPTIONS")`NodeHttpConfigFetcher.fetchAsync() requestOptions: ${requestOptionsSafe}`);
-        }
-
-        const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, resolve, reject))
-          .on("timeout", () => {
-            try {
-              clientRequest.destroy();
-            } finally {
-              reject(new FetchError("timeout", timeoutMs));
-            }
-          })
-          .on("error", err => {
-            reject(new FetchError("failure", err));
-          })
-          .end();
-      } catch (err) {
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        reject(err);
+      if (isCustomUrl) {
+        this.setRequestHeaders(requestOptions, request.headers);
+      } else {
+        setRequestHeadersDefault(requestOptions, request.headers);
       }
+
+      if (lastETag) {
+        (requestOptions.headers ??= {})["If-None-Match"] = lastETag;
+      }
+
+      if (logger?.isEnabled(LogLevel.Debug)) {
+        const requestOptionsSafe = JSON.stringify({ ...requestOptions, agent: toStringSafe(requestOptions.agent) });
+        logger.debug(FormattableLogMessage.from("OPTIONS")`NodeHttpConfigFetcher.fetchAsync() requestOptions: ${requestOptionsSafe}`);
+      }
+
+      const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, resolve, reject))
+        .on("timeout", () => {
+          try {
+            clientRequest.destroy();
+          } finally {
+            reject(new FetchError("timeout", timeoutMs));
+          }
+        })
+        .on("error", err => {
+          reject(new FetchError("failure", err));
+        })
+        .end();
     });
   }
 

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -4,9 +4,9 @@ import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, LogLevel } from "../ConfigCatLogger";
-import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, fetchInternalAsyncMethodName, FetchResponse } from "../ConfigFetcher";
-import { ensureObjectArg, hasOwnProperty, isArray, toStringSafe } from "../Utils";
+import type { FetchInternalAsyncMethodType, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
+import { delay, ensureObjectArg, hasOwnProperty, isArray, toStringSafe } from "../Utils";
 
 export interface INodeHttpConfigFetcherOptions {
   /**
@@ -92,10 +92,11 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     return this[fetchInternalAsyncMethodName](request);
   }
 
-  private [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
-    return new Promise<FetchResponse>((resolve, reject) => {
-      logger?.debug("NodeHttpConfigFetcher.fetchAsync() called.");
+  // Defined directly on the prototype, see below.
+  private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethodType<NodeHttpConfigFetcher>;
 
+  private fetchCoreAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
+    return new Promise<FetchResponse>((resolve, reject) => {
       const { url } = request;
       const isCustomUrl = !isCdnUrl(url);
       const isHttpsUrl = url.startsWith("https:");
@@ -140,6 +141,27 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     setRequestHeadersDefault(requestOptions, headers);
   }
 }
+
+NodeHttpConfigFetcher.prototype[fetchInternalAsyncMethodName] = async function(request: FetchRequest, logger?: LoggerWrapper) {
+  logger?.debug("NodeHttpConfigFetcher.fetchAsync() called.");
+
+  for (let retryNumber = 0; ; retryNumber++) {
+    try {
+      const fetchResponse = await this["fetchCoreAsync"](request, logger);
+      if (FetchResponse.prototype.isExpected.call(fetchResponse) || retryNumber >= fetchRetryLimit) {
+        return fetchResponse;
+      }
+    } catch (err) {
+      if (retryNumber >= fetchRetryLimit
+        || !(err instanceof FetchError)
+        || (err as FetchError).cause !== "timeout" && (err as FetchError).cause !== "failure") {
+        throw err;
+      }
+    }
+
+    await delay(fetchRetryDelayMs);
+  }
+};
 
 function setRequestHeadersDefault(requestOptions: { headers?: Record<string, http.OutgoingHttpHeader> }, headers: ReadonlyArray<readonly [string, string]>): void {
   if (headers.length) {

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -5,7 +5,7 @@ import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, LogLevel } from "../ConfigCatLogger";
 import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, FetchResponse } from "../ConfigFetcher";
+import { FetchError, fetchInternalAsyncMethodName, FetchResponse } from "../ConfigFetcher";
 import { ensureObjectArg, hasOwnProperty, isArray, toStringSafe } from "../Utils";
 
 export interface INodeHttpConfigFetcherOptions {
@@ -32,14 +32,8 @@ export interface INodeHttpConfigFetcherOptions {
 
 export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
   private static getFactory(fetcherOptions?: INodeHttpConfigFetcherOptions): (options: OptionsBase) => IConfigCatConfigFetcher {
-    return options => {
-      const configFetcher = new NodeHttpConfigFetcher(fetcherOptions);
-      configFetcher.logger = options.logger;
-      return configFetcher;
-    };
+    return () => new NodeHttpConfigFetcher(fetcherOptions);
   }
-
-  private logger: LoggerWrapper | null = null;
 
   private readonly httpAgent: http.Agent | undefined;
   private readonly httpsAgent: https.Agent | undefined;
@@ -95,9 +89,13 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
   }
 
   fetchAsync(request: FetchRequest): Promise<FetchResponse> {
+    return this[fetchInternalAsyncMethodName](request);
+  }
+
+  private [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
       try {
-        this.logger?.debug("NodeHttpConfigFetcher.fetchAsync() called.");
+        logger?.debug("NodeHttpConfigFetcher.fetchAsync() called.");
 
         const { url } = request;
         const isCustomUrl = !isCdnUrl(url);
@@ -119,9 +117,9 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
           (requestOptions.headers ??= {})["If-None-Match"] = lastETag;
         }
 
-        if (this.logger?.isEnabled(LogLevel.Debug)) {
+        if (logger?.isEnabled(LogLevel.Debug)) {
           const requestOptionsSafe = JSON.stringify({ ...requestOptions, agent: toStringSafe(requestOptions.agent) });
-          this.logger.debug(FormattableLogMessage.from("OPTIONS")`NodeHttpConfigFetcher.fetchAsync() requestOptions: ${requestOptionsSafe}`);
+          logger.debug(FormattableLogMessage.from("OPTIONS")`NodeHttpConfigFetcher.fetchAsync() requestOptions: ${requestOptionsSafe}`);
         }
 
         const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, resolve, reject))

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -3,7 +3,7 @@ import * as https from "https";
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
-import { FormattableLogMessage, LogLevel } from "../ConfigCatLogger";
+import { FormattableLogMessage, LogLevel, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { connectionPoolResetThresholdMs, FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
 import { delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, toStringSafe } from "../Utils";
@@ -283,8 +283,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
 }
 
 NodeHttpConfigFetcher.prototype[fetchInternalAsyncMethodName] = function(request: FetchRequest, logger?: LoggerWrapper) {
-  logger?.debug("NodeHttpConfigFetcher.fetchAsync() called.");
-
+  logMethodDebug(logger, "NodeHttpConfigFetcher.fetchAsync");
   return this["fetchWithRetryAsync"](request, logger);
 };
 

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -4,9 +4,15 @@ import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
-import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { connectionPoolResetThresholdMs, FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit, requestIdArgName } from "../ConfigFetcher";
 import { delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, randomUUID, toStringSafe } from "../Utils";
+
+type FetchContext = {
+  readonly debugLogger: LoggerWrapper | undefined;
+  readonly requestId: string | undefined;
+  rayId: string | undefined;
+};
 
 export interface INodeHttpConfigFetcherOptions {
   /**
@@ -127,10 +133,10 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
   }
 
   private handleResponse(
-    response: http.IncomingMessage, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void,
-    requestId: string | undefined, debugLogger: LoggerWrapper | undefined
+    response: http.IncomingMessage, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void, context: FetchContext
   ) {
     try {
+      const { debugLogger, requestId } = context;
       const { statusCode, statusMessage: reasonPhrase } = response as { statusCode: number; statusMessage: string };
 
       if (debugLogger) {
@@ -142,6 +148,8 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       const headers = getResponseHeadersDefault(response);
+      const fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers);
+      const rayId = context.rayId = fetchResponse["rayId"];
 
       if (statusCode === 200) {
         const chunks: any[] = [];
@@ -149,23 +157,23 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
           .on("data", chunk => chunks.push(chunk))
           .on("end", () => {
             try {
-              const body = Buffer.concat(chunks).toString();
+              const body = (fetchResponse as { body: string }).body = Buffer.concat(chunks).toString();
 
               debugLogger?.debug(FormattableLogMessage.from(
                 requestIdArgName, "LENGTH"
               )`[${requestId}] Received body. (Length: ${body.length})`);
 
-              resolve(new FetchResponse(statusCode, reasonPhrase, headers, body));
+              resolve(fetchResponse);
             } catch (err) {
               reject(err);
             }
           })
-          .on("error", err => reject(new FetchError("failure", err)));
+          .on("error", err => reject(new (FetchError as FetchErrorCtorInternal)("failure", err, rayId)));
       } else {
         // Consume response data to free up memory
         response.resume();
 
-        resolve(new FetchResponse(statusCode, reasonPhrase, headers));
+        resolve(fetchResponse);
       }
     } catch (err) {
       reject(err);
@@ -217,7 +225,8 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       try {
-        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, isHttpsUrl, agent, requestId, debugLogger);
+        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, isHttpsUrl, agent,
+          { debugLogger, requestId, rayId: void 0 });
 
         if (FetchResponse.prototype.isExpected.call(fetchResponse)) {
           return fetchResponse;
@@ -291,10 +300,10 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
   }
 
   private fetchCoreAsync(
-    request: FetchRequest, isCustomUrl: boolean, isHttpsUrl: boolean, agent: http.Agent | https.Agent,
-    requestId: string | undefined, debugLogger: LoggerWrapper | undefined
+    request: FetchRequest, isCustomUrl: boolean, isHttpsUrl: boolean, agent: http.Agent | https.Agent, context: FetchContext
   ): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
+      const { debugLogger, requestId } = context;
       const { url, lastETag, timeoutMs } = request;
 
       const requestOptions = Object.create(null) as (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> };
@@ -318,23 +327,22 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
         )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${lastETag ?? ""}', Options: ${requestOptionsSafe})`);
       }
 
-      const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions,
-        response => this.handleResponse(response, resolve, reject, requestId, debugLogger))
+      const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, resolve, reject, context))
         .on("timeout", () => {
           try {
             clientRequest.destroy();
           } finally {
-            reject(new FetchError("timeout", timeoutMs));
+            reject(new (FetchError as FetchErrorCtorInternal)("timeout", timeoutMs, context.rayId));
           }
         })
         .on("close", () => {
           // eslint-disable-next-line @typescript-eslint/no-deprecated
           if (typeof clientRequest.aborted !== "undefined" ? clientRequest.aborted : clientRequest.destroyed) {
-            reject(new FetchError("abort"));
+            reject(new (FetchError as FetchErrorCtorInternal)("abort", context.rayId));
           }
         })
         .on("error", err => {
-          reject(new FetchError("failure", err));
+          reject(new (FetchError as FetchErrorCtorInternal)("failure", err, context.rayId));
         })
         .end();
     });

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -5,8 +5,8 @@ import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, LogLevel } from "../ConfigCatLogger";
 import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
-import { delay, ensureObjectArg, hasOwnProperty, isArray, toStringSafe } from "../Utils";
+import { connectionPoolResetThresholdMs, FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
+import { delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, toStringSafe } from "../Utils";
 
 export interface INodeHttpConfigFetcherOptions {
   /**
@@ -17,8 +17,30 @@ export interface INodeHttpConfigFetcherOptions {
    * will be used.
    *
    * This option applies when the SDK connects to a custom `http://...` URL you specified via `baseUrl`.
+   *
+   * @remarks If this and `httpAgentFactory` options are both specified, this option is ignored.
+   *
+   * @deprecated This option is kept for backward compatibility but will be removed in a future major version.
+   * Please use the `httpAgentFactory` option instead.
    */
   httpAgent?: http.Agent | null;
+
+  /**
+   * An optional callback to override the creation of {@link https://nodejs.org/api/http.html#class-httpagent | http.Agent}
+   * instances for non-secure HTTP communication. For example, this option allows you to configure the SDK to route
+   * `http://...` requests through an HTTP, HTTPS or SOCKS proxy.
+   *
+   * If not set, an internally managed agent with the same options as {@link https://nodejs.org/api/http.html#httpglobalagent | http.globalAgent}
+   * will be used.
+   *
+   * This option applies when the SDK connects to a custom `http://...` URL you specified via `baseUrl`.
+   *
+   * @remarks The callback must always return a new `http.Agent` instance and leave lifetime management of that instance to the SDK.
+   *
+   * @param recommendedOptions Default options for the agent to create. This object can be modified as needed.
+   * @returns The `http.Agent` instance to use for making requests.
+   */
+  httpAgentFactory?: ((recommendedOptions: http.AgentOptions) => http.Agent) | null;
 
   /**
    * The {@link https://nodejs.org/api/https.html#class-httpsagent | https.Agent} instance to use for secure HTTP communication.
@@ -28,8 +50,30 @@ export interface INodeHttpConfigFetcherOptions {
    * will be used.
    *
    * This option applies when the SDK connects to the ConfigCat CDN or a custom `https://...` URL you specified via `baseUrl`.
-   */
+   *
+   * @remarks If this and `httpsAgentFactory` options are both specified, this option is ignored.
+   *
+   * @deprecated This option is kept for backward compatibility but will be removed in a future major version.
+   * Please use the `httpsAgentFactory` option instead.
+  */
   httpsAgent?: https.Agent | null;
+
+  /**
+   * An optional callback to override the creation of {@link https://nodejs.org/api/https.html#class-httpsagent | https.Agent}
+   * instances for secure HTTP communication. For example, this option allows you to configure the SDK to route
+   * `https://...` requests through an HTTP, HTTPS or SOCKS proxy.
+   *
+   * If not set, an internally managed agent with the same options as {@link https://nodejs.org/api/https.html#httpsglobalagent | https.globalAgent}
+   * will be used.
+   *
+   * This option applies when the SDK connects to the ConfigCat CDN or a custom `https://...` URL you specified via `baseUrl`.
+   *
+   * @remarks The callback must always return a new `https.Agent` instance and leave lifetime management of that instance to the SDK.
+   *
+   * @param recommendedOptions Default options for the agent to create. This object can be modified as needed.
+   * @returns The `https.Agent` instance to use for making requests.
+   */
+  httpsAgentFactory?: ((recommendedOptions: https.AgentOptions) => https.Agent) | null;
 }
 
 export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
@@ -37,51 +81,48 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     return () => new NodeHttpConfigFetcher(fetcherOptions);
   }
 
-  private httpAgent: http.Agent | undefined;
-  private readonly ownsHttpAgent: boolean;
-
-  private httpsAgent: https.Agent | undefined;
-  private readonly ownsHttpsAgent: boolean;
-
-  private isDisposed = false;
+  private httpAgentState: AgentState<http.Agent> | http.Agent | undefined; // undefined indicates disposed state
+  private httpsAgentState: AgentState<https.Agent> | https.Agent | undefined; // undefined indicates disposed state
 
   constructor(options?: INodeHttpConfigFetcherOptions) {
-    let httpAgent: http.Agent | undefined, httpsAgent: https.Agent | undefined;
+    let httpAgent: http.Agent | undefined, httpAgentFactory: INodeHttpConfigFetcherOptions["httpAgentFactory"] | undefined;
+    let httpsAgent: https.Agent | undefined, httpsAgentFactory: INodeHttpConfigFetcherOptions["httpsAgentFactory"] | undefined;
 
     if (options != null) {
       const optionsArgName = "options";
 
       ensureObjectArg(options, optionsArgName);
 
-      if (options.httpAgent != null) {
+      /* eslint-disable @typescript-eslint/no-deprecated */
+
+      if (options.httpAgentFactory != null) {
+        httpAgentFactory = ensureFunctionArg(options.httpAgentFactory, optionsArgName, ".httpAgentFactory");
+      } else if (options.httpAgent != null) {
         httpAgent = ensureObjectArg(options.httpAgent, optionsArgName, void 0, ".httpAgent");
       }
 
-      if (options.httpsAgent != null) {
+      if (options.httpsAgentFactory != null) {
+        httpsAgentFactory = ensureFunctionArg(options.httpsAgentFactory, optionsArgName, ".httpsAgentFactory");
+      } else if (options.httpsAgent != null) {
         httpsAgent = ensureObjectArg(options.httpsAgent, optionsArgName, void 0, ".httpsAgent");
       }
+
+      /* eslint-enable @typescript-eslint/no-deprecated */
     }
 
-    this.httpAgent = httpAgent;
-    this.ownsHttpAgent = !httpAgent;
-
-    this.httpsAgent = httpsAgent;
-    this.ownsHttpsAgent = !httpsAgent;
+    this.httpAgentState = httpAgent ?? new AgentState(httpAgentFactory ?? (options => new http.Agent(options)));
+    this.httpsAgentState = httpsAgent ?? new AgentState(httpsAgentFactory ?? (options => new https.Agent(options)));
   }
 
   dispose(): void {
-    if (!this.isDisposed) {
-      this.isDisposed = true;
-
-      if (this.ownsHttpAgent) {
-        this.httpAgent?.destroy();
-        this.httpAgent = void 0;
-      }
-
-      if (this.ownsHttpsAgent) {
-        this.httpsAgent?.destroy();
-        this.httpsAgent = void 0;
-      }
+    const { httpAgentState, httpsAgentState } = this;
+    // Release agent objects and factory callbacks so GC can collect them.
+    this.httpAgentState = this.httpsAgentState = void 0;
+    if (httpAgentState instanceof AgentState) {
+      httpAgentState.agent?.destroy();
+    }
+    if (httpsAgentState instanceof AgentState) {
+      httpsAgentState.agent?.destroy();
     }
   }
 
@@ -121,23 +162,83 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
   // Defined directly on the prototype, see below.
   private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethod<NodeHttpConfigFetcher>;
 
-  private fetchCoreAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
-    return new Promise<FetchResponse>((resolve, reject) => {
-      if (this.isDisposed) {
-        reject(new FetchError("abort"));
-        return;
+  private async fetchWithRetryAsync(request: FetchRequest, logger?: LoggerWrapper) {
+    const { url } = request;
+    const isCustomUrl = !isCdnUrl(url);
+    const isHttpsUrl = /^https:/i.test(url);
+
+    for (let retryNumber = 0; ; retryNumber++) {
+      const agentStateOrExternalAgent = isHttpsUrl ? this.httpsAgentState : this.httpAgentState;
+      if (!agentStateOrExternalAgent) { // has config fetcher been disposed?
+        throw retryNumber > 0 ? new FetchError("abort") : Error(`${this.constructor.name} object has been disposed.`);
       }
 
-      const { url } = request;
-      const isCustomUrl = !isCdnUrl(url);
-      const isHttpsUrl = url.startsWith("https:");
+      const [agentState, agent] = agentStateOrExternalAgent instanceof AgentState
+        ? [agentStateOrExternalAgent as AgentState<http.Agent | https.Agent>, agentStateOrExternalAgent.getOrCreateAgent()]
+        // eslint-disable-next-line no-sparse-arrays
+        : [, agentStateOrExternalAgent];
 
-      const { lastETag, timeoutMs } = request;
+      let shouldRenewAgent = false;
+
+      if (agentState) {
+        if (agentState.numRequestsInProgress < 0) {
+          // Execution should never get here. If it does, there's a bug in the agent renewal and/or usage counter logic.
+          // Just to be sure, throw an exception in this case.
+          throw Error(`${this.constructor.name} object got into an invalid state.`);
+        }
+
+        agentState.numRequestsInProgress++;
+      }
+
+      try {
+        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, isHttpsUrl, agent, logger);
+        shouldRenewAgent = !FetchResponse.prototype.isExpected.call(fetchResponse);
+        if (!shouldRenewAgent || retryNumber >= fetchRetryLimit) {
+          return fetchResponse;
+        }
+      } catch (err) {
+        shouldRenewAgent = err instanceof FetchError
+          && ((err as FetchError).cause === "timeout" || (err as FetchError).cause === "failure");
+        if (!shouldRenewAgent || retryNumber >= fetchRetryLimit) {
+          throw err;
+        }
+      } finally {
+        if (agentState) {
+          let numRequestsToSubtract = 1;
+          try {
+            if (shouldRenewAgent && agentState.canRenew(connectionPoolResetThresholdMs)) {
+              const currentAgentState = isHttpsUrl ? this.httpsAgentState : this.httpAgentState;
+              if (agentState === currentAgentState) {
+                isHttpsUrl
+                  ? this.httpsAgentState = (agentState as AgentState<https.Agent>).renew()
+                  : this.httpAgentState = (agentState as AgentState<http.Agent>).renew();
+
+                // This will cause the `numRequestsInProgress` counter to go below zero eventually, indicating that a new
+                // agent has been created and the original one is not to be used anymore as it will be destroyed (see below).
+                numRequestsToSubtract = 2;
+              }
+            }
+          } finally {
+            if ((agentState.numRequestsInProgress -= numRequestsToSubtract) < 0) {
+              agent.destroy();
+            }
+          }
+        }
+      }
+
+      // Wait a little before trying again.
+      await delay(fetchRetryDelayMs);
+    }
+  }
+
+  private fetchCoreAsync(
+    request: FetchRequest, isCustomUrl: boolean, isHttpsUrl: boolean, agent: http.Agent | https.Agent, logger?: LoggerWrapper
+  ): Promise<FetchResponse> {
+    return new Promise<FetchResponse>((resolve, reject) => {
+      const { url, lastETag, timeoutMs } = request;
 
       const requestOptions = Object.create(null) as (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> };
-      requestOptions.agent = isHttpsUrl
-        ? (this.httpsAgent ??= new https.Agent(getInternalAgentOptions()))
-        : (this.httpAgent ??= new http.Agent(getInternalAgentOptions()));
+      requestOptions.agent = agent;
       requestOptions.timeout = timeoutMs;
 
       if (isCustomUrl) {
@@ -181,25 +282,10 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
   }
 }
 
-NodeHttpConfigFetcher.prototype[fetchInternalAsyncMethodName] = async function(request: FetchRequest, logger?: LoggerWrapper) {
+NodeHttpConfigFetcher.prototype[fetchInternalAsyncMethodName] = function(request: FetchRequest, logger?: LoggerWrapper) {
   logger?.debug("NodeHttpConfigFetcher.fetchAsync() called.");
 
-  for (let retryNumber = 0; ; retryNumber++) {
-    try {
-      const fetchResponse = await this["fetchCoreAsync"](request, logger);
-      if (FetchResponse.prototype.isExpected.call(fetchResponse) || retryNumber >= fetchRetryLimit) {
-        return fetchResponse;
-      }
-    } catch (err) {
-      if (retryNumber >= fetchRetryLimit
-        || !(err instanceof FetchError)
-        || (err as FetchError).cause !== "timeout" && (err as FetchError).cause !== "failure") {
-        throw err;
-      }
-    }
-
-    await delay(fetchRetryDelayMs);
-  }
+  return this["fetchWithRetryAsync"](request, logger);
 };
 
 function setRequestHeadersDefault(requestOptions: { headers?: Record<string, http.OutgoingHttpHeader> }, headers: ReadonlyArray<readonly [string, string]>): void {
@@ -232,11 +318,30 @@ function getResponseHeadersDefault(httpResponse: http.IncomingMessage): [string,
   }
 }
 
-function getInternalAgentOptions(): http.AgentOptions & https.AgentOptions {
-  // Use the same defaults as http.globalAgent (see https://nodejs.org/api/http.html#httpglobalagent) and
-  // https.globalAgent (see https://nodejs.org/api/https.html#httpsglobalagent).
-  return {
-    keepAlive: true,
-    timeout: 5000,
-  };
+class AgentState<TAgent extends http.Agent | https.Agent> {
+  agent: TAgent | undefined = void 0;
+  numRequestsInProgress = 0; // a negative value indicates that the agent shouldn't be used anymore
+
+  constructor(
+    private readonly agentFactory: (options: http.AgentOptions | https.AgentOptions) => TAgent,
+    private readonly renewalTimeMs = -Infinity
+  ) {
+  }
+
+  getOrCreateAgent() {
+    // Use the same defaults as http.globalAgent (see https://nodejs.org/api/http.html#httpglobalagent) and
+    // https.globalAgent (see https://nodejs.org/api/https.html#httpsglobalagent).
+    return this.agent ??= this.agentFactory({
+      keepAlive: true,
+      timeout: 5000,
+    });
+  }
+
+  canRenew(thresholdMs: number) {
+    return getMonotonicTimeMs() - this.renewalTimeMs > thresholdMs;
+  }
+
+  renew() {
+    return new AgentState(this.agentFactory, getMonotonicTimeMs());
+  }
 }

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -143,54 +143,6 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     }
   }
 
-  private handleResponse(
-    response: http.IncomingMessage, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void, context: FetchContext
-  ) {
-    try {
-      const { debugLogger, requestId } = context;
-      const { statusCode, statusMessage: reasonPhrase } = response as { statusCode: number; statusMessage: string };
-
-      if (debugLogger) {
-        const { headers } = response;
-        const eTagHeaderValue = hasOwnProperty(headers, "etag") ? headers["etag"] : void 0;
-        debugLogger.debug(FormattableLogMessage.from(
-          REQUEST_ID_ARG_NAME, "STATUS_CODE", "REASON_PHRASE", "ETAG"
-        )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
-      }
-
-      const headers = getResponseHeadersDefault(response);
-      const fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers);
-      const rayId = context.rayId = fetchResponse["rayId"];
-
-      if (statusCode === 200) {
-        const chunks: any[] = [];
-        response
-          .on("data", chunk => chunks.push(chunk))
-          .on("end", () => {
-            try {
-              const body = (fetchResponse as { body: string }).body = Buffer.concat(chunks).toString();
-
-              debugLogger?.debug(FormattableLogMessage.from(
-                REQUEST_ID_ARG_NAME, "LENGTH"
-              )`[${requestId}] Received body. (Length: ${body.length})`);
-
-              resolve(fetchResponse);
-            } catch (err) {
-              reject(err);
-            }
-          })
-          .on("error", err => reject(new (FetchError as FetchErrorCtorInternal)("failure", err, rayId)));
-      } else {
-        // Consume response data to free up memory
-        response.resume();
-
-        resolve(fetchResponse);
-      }
-    } catch (err) {
-      reject(err);
-    }
-  }
-
   fetchAsync(request: FetchRequest): Promise<FetchResponse> {
     return this[fetchInternalAsyncMethodName](request);
   }
@@ -376,6 +328,54 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
         })
         .end();
     }).finally(() => unregisterFromDisposeToken?.());
+  }
+
+  private handleResponse(
+    response: http.IncomingMessage, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void, context: FetchContext
+  ) {
+    try {
+      const { debugLogger, requestId } = context;
+      const { statusCode, statusMessage: reasonPhrase } = response as { statusCode: number; statusMessage: string };
+
+      if (debugLogger) {
+        const { headers } = response;
+        const eTagHeaderValue = hasOwnProperty(headers, "etag") ? headers["etag"] : void 0;
+        debugLogger.debug(FormattableLogMessage.from(
+          REQUEST_ID_ARG_NAME, "STATUS_CODE", "REASON_PHRASE", "ETAG"
+        )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
+      }
+
+      const headers = getResponseHeadersDefault(response);
+      const fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers);
+      const rayId = context.rayId = fetchResponse["rayId"];
+
+      if (statusCode === 200) {
+        const chunks: any[] = [];
+        response
+          .on("data", chunk => chunks.push(chunk))
+          .on("end", () => {
+            try {
+              const body = (fetchResponse as { body: string }).body = Buffer.concat(chunks).toString();
+
+              debugLogger?.debug(FormattableLogMessage.from(
+                REQUEST_ID_ARG_NAME, "LENGTH"
+              )`[${requestId}] Received body. (Length: ${body.length})`);
+
+              resolve(fetchResponse);
+            } catch (err) {
+              reject(err);
+            }
+          })
+          .on("error", err => reject(new (FetchError as FetchErrorCtorInternal)("failure", err, rayId)));
+      } else {
+        // Consume response data to free up memory
+        response.resume();
+
+        resolve(fetchResponse);
+      }
+    } catch (err) {
+      reject(err);
+    }
   }
 
   protected setRequestHeaders(requestOptions: { headers?: Record<string, number | string | string[]> }, headers: ReadonlyArray<readonly [string, string]>): void {

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -4,7 +4,7 @@ import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, LogLevel } from "../ConfigCatLogger";
-import type { FetchInternalAsyncMethodType, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
 import { delay, ensureObjectArg, hasOwnProperty, isArray, toStringSafe } from "../Utils";
 
@@ -13,7 +13,8 @@ export interface INodeHttpConfigFetcherOptions {
    * The {@link https://nodejs.org/api/http.html#class-httpagent | http.Agent} instance to use for non-secure HTTP communication.
    * For example, this option allows you to configure the SDK to route `http://...` requests through an HTTP, HTTPS or SOCKS proxy.
    *
-   * If not set, the default agent, {@link https://nodejs.org/api/http.html#httpglobalagent | http.globalAgent} will be used.
+   * If not set, an internally managed agent with the same options as {@link https://nodejs.org/api/http.html#httpglobalagent | http.globalAgent}
+   * will be used.
    *
    * This option applies when the SDK connects to a custom `http://...` URL you specified via `baseUrl`.
    */
@@ -23,7 +24,8 @@ export interface INodeHttpConfigFetcherOptions {
    * The {@link https://nodejs.org/api/https.html#class-httpsagent | https.Agent} instance to use for secure HTTP communication.
    * For example, this option allows you to configure the SDK to route `https://...` requests through an HTTP, HTTPS or SOCKS proxy.
    *
-   * If not set, the default agent, {@link https://nodejs.org/api/https.html#httpsglobalagent | https.globalAgent} will be used.
+   * If not set, an internally managed agent with the same options as {@link https://nodejs.org/api/https.html#httpsglobalagent | https.globalAgent}
+   * will be used.
    *
    * This option applies when the SDK connects to the ConfigCat CDN or a custom `https://...` URL you specified via `baseUrl`.
    */
@@ -35,8 +37,13 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     return () => new NodeHttpConfigFetcher(fetcherOptions);
   }
 
-  private readonly httpAgent: http.Agent | undefined;
-  private readonly httpsAgent: https.Agent | undefined;
+  private httpAgent: http.Agent | undefined;
+  private readonly ownsHttpAgent: boolean;
+
+  private httpsAgent: https.Agent | undefined;
+  private readonly ownsHttpsAgent: boolean;
+
+  private isDisposed = false;
 
   constructor(options?: INodeHttpConfigFetcherOptions) {
     let httpAgent: http.Agent | undefined, httpsAgent: https.Agent | undefined;
@@ -56,7 +63,26 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     }
 
     this.httpAgent = httpAgent;
+    this.ownsHttpAgent = !httpAgent;
+
     this.httpsAgent = httpsAgent;
+    this.ownsHttpsAgent = !httpsAgent;
+  }
+
+  dispose(): void {
+    if (!this.isDisposed) {
+      this.isDisposed = true;
+
+      if (this.ownsHttpAgent) {
+        this.httpAgent?.destroy();
+        this.httpAgent = void 0;
+      }
+
+      if (this.ownsHttpsAgent) {
+        this.httpsAgent?.destroy();
+        this.httpsAgent = void 0;
+      }
+    }
   }
 
   private handleResponse(response: http.IncomingMessage, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
@@ -93,10 +119,15 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
   }
 
   // Defined directly on the prototype, see below.
-  private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethodType<NodeHttpConfigFetcher>;
+  private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethod<NodeHttpConfigFetcher>;
 
   private fetchCoreAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
+      if (this.isDisposed) {
+        reject(new FetchError("abort"));
+        return;
+      }
+
       const { url } = request;
       const isCustomUrl = !isCdnUrl(url);
       const isHttpsUrl = url.startsWith("https:");
@@ -104,7 +135,9 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
       const { lastETag, timeoutMs } = request;
 
       const requestOptions = Object.create(null) as (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> };
-      requestOptions.agent = isHttpsUrl ? this.httpsAgent : this.httpAgent;
+      requestOptions.agent = isHttpsUrl
+        ? (this.httpsAgent ??= new https.Agent(getInternalAgentOptions()))
+        : (this.httpAgent ??= new http.Agent(getInternalAgentOptions()));
       requestOptions.timeout = timeoutMs;
 
       if (isCustomUrl) {
@@ -128,6 +161,12 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
             clientRequest.destroy();
           } finally {
             reject(new FetchError("timeout", timeoutMs));
+          }
+        })
+        .on("close", () => {
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
+          if (typeof clientRequest.aborted !== "undefined" ? clientRequest.aborted : clientRequest.destroyed) {
+            reject(new FetchError("abort"));
           }
         })
         .on("error", err => {
@@ -191,4 +230,13 @@ function getResponseHeadersDefault(httpResponse: http.IncomingMessage): [string,
       headers.push([name, !isArray(value) ? value : value[0]]);
     }
   }
+}
+
+function getInternalAgentOptions(): http.AgentOptions & https.AgentOptions {
+  // Use the same defaults as http.globalAgent (see https://nodejs.org/api/http.html#httpglobalagent) and
+  // https.globalAgent (see https://nodejs.org/api/https.html#httpsglobalagent).
+  return {
+    keepAlive: true,
+    timeout: 5000,
+  };
 }

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -3,10 +3,10 @@ import * as https from "https";
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
-import { FormattableLogMessage, LogLevel, logMethodDebug } from "../ConfigCatLogger";
+import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { connectionPoolResetThresholdMs, FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
-import { delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, toStringSafe } from "../Utils";
+import { connectionPoolResetThresholdMs, FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit, requestIdArgName } from "../ConfigFetcher";
+import { delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, randomUUID, toStringSafe } from "../Utils";
 
 export interface INodeHttpConfigFetcherOptions {
   /**
@@ -126,9 +126,21 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     }
   }
 
-  private handleResponse(response: http.IncomingMessage, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void) {
+  private handleResponse(
+    response: http.IncomingMessage, resolve: (value: FetchResponse) => void, reject: (reason?: any) => void,
+    requestId: string | undefined, debugLogger: LoggerWrapper | undefined
+  ) {
     try {
       const { statusCode, statusMessage: reasonPhrase } = response as { statusCode: number; statusMessage: string };
+
+      if (debugLogger) {
+        const { headers } = response;
+        const eTagHeaderValue = hasOwnProperty(headers, "etag") ? headers["etag"] : void 0;
+        debugLogger.debug(FormattableLogMessage.from(
+          requestIdArgName, "STATUS_CODE", "REASON_PHRASE", "ETAG"
+        )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
+      }
+
       const headers = getResponseHeadersDefault(response);
 
       if (statusCode === 200) {
@@ -138,6 +150,11 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
           .on("end", () => {
             try {
               const body = Buffer.concat(chunks).toString();
+
+              debugLogger?.debug(FormattableLogMessage.from(
+                requestIdArgName, "LENGTH"
+              )`[${requestId}] Received body. (Length: ${body.length})`);
+
               resolve(new FetchResponse(statusCode, reasonPhrase, headers, body));
             } catch (err) {
               reject(err);
@@ -162,7 +179,16 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
   // Defined directly on the prototype, see below.
   private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethod<NodeHttpConfigFetcher>;
 
-  private async fetchWithRetryAsync(request: FetchRequest, logger?: LoggerWrapper) {
+  private async fetchWithRetryAsync(request: FetchRequest, logger: LoggerWrapper | undefined) {
+    const debugLogger = logger?.ifDebug;
+    let requestId: string | undefined;
+
+    if (debugLogger) {
+      requestId = randomUUID();
+
+      debugLogger.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Preparing request...`);
+    }
+
     const { url } = request;
     const isCustomUrl = !isCdnUrl(url);
     const isHttpsUrl = /^https:/i.test(url);
@@ -191,15 +217,38 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       try {
-        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, isHttpsUrl, agent, logger);
-        shouldRenewAgent = !FetchResponse.prototype.isExpected.call(fetchResponse);
-        if (!shouldRenewAgent || retryNumber >= fetchRetryLimit) {
+        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, isHttpsUrl, agent, requestId, debugLogger);
+
+        if (FetchResponse.prototype.isExpected.call(fetchResponse)) {
+          return fetchResponse;
+        }
+
+        shouldRenewAgent = true;
+        debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Received unexpected status code.`);
+
+        if (retryNumber >= fetchRetryLimit) {
           return fetchResponse;
         }
       } catch (err) {
-        shouldRenewAgent = err instanceof FetchError
-          && ((err as FetchError).cause === "timeout" || (err as FetchError).cause === "failure");
-        if (!shouldRenewAgent || retryNumber >= fetchRetryLimit) {
+        if (err instanceof FetchError) {
+          switch ((err as FetchError).cause) {
+            case "abort":
+              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request aborted.`);
+              throw err;
+            case "timeout":
+              shouldRenewAgent = true;
+              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request timed out.`);
+              break;
+            case "failure":
+              shouldRenewAgent = true;
+              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request failed.`);
+              break;
+          }
+        } else {
+          throw err;
+        }
+
+        if (retryNumber >= fetchRetryLimit) {
           throw err;
         }
       } finally {
@@ -216,11 +265,19 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
                 // This will cause the `numRequestsInProgress` counter to go below zero eventually, indicating that a new
                 // agent has been created and the original one is not to be used anymore as it will be destroyed (see below).
                 numRequestsToSubtract = 2;
+
+                debugLogger?.debug(isHttpsUrl
+                  ? FormattableLogMessage.from(requestIdArgName)`[${requestId}] Renewed https.Agent.`
+                  : FormattableLogMessage.from(requestIdArgName)`[${requestId}] Renewed http.Agent.`);
               }
             }
           } finally {
             if ((agentState.numRequestsInProgress -= numRequestsToSubtract) < 0) {
               agent.destroy();
+
+              debugLogger?.debug(isHttpsUrl
+                ? FormattableLogMessage.from(requestIdArgName)`[${requestId}] Disposed out-of-use https.Agent.`
+                : FormattableLogMessage.from(requestIdArgName)`[${requestId}] Disposed out-of-use http.Agent.`);
             }
           }
         }
@@ -228,11 +285,14 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
 
       // Wait a little before trying again.
       await delay(fetchRetryDelayMs);
+
+      debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Trying request again...`);
     }
   }
 
   private fetchCoreAsync(
-    request: FetchRequest, isCustomUrl: boolean, isHttpsUrl: boolean, agent: http.Agent | https.Agent, logger?: LoggerWrapper
+    request: FetchRequest, isCustomUrl: boolean, isHttpsUrl: boolean, agent: http.Agent | https.Agent,
+    requestId: string | undefined, debugLogger: LoggerWrapper | undefined
   ): Promise<FetchResponse> {
     return new Promise<FetchResponse>((resolve, reject) => {
       const { url, lastETag, timeoutMs } = request;
@@ -251,12 +311,15 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
         (requestOptions.headers ??= {})["If-None-Match"] = lastETag;
       }
 
-      if (logger?.isEnabled(LogLevel.Debug)) {
+      if (debugLogger) {
         const requestOptionsSafe = JSON.stringify({ ...requestOptions, agent: toStringSafe(requestOptions.agent) });
-        logger.debug(FormattableLogMessage.from("OPTIONS")`NodeHttpConfigFetcher.fetchAsync() requestOptions: ${requestOptionsSafe}`);
+        debugLogger.debug(FormattableLogMessage.from(
+          requestIdArgName, "URL", "IF_NONE_MATCH", "OPTIONS"
+        )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${lastETag ?? ""}', Options: ${requestOptionsSafe})`);
       }
 
-      const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, resolve, reject))
+      const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions,
+        response => this.handleResponse(response, resolve, reject, requestId, debugLogger))
         .on("timeout", () => {
           try {
             clientRequest.destroy();

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -6,7 +6,7 @@ import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { CONNECTIONPOOL_RESET_THRESHOLD_MS, FETCH_RETRY_DELAY_MS, FETCH_RETRY_LIMIT, FetchError, fetchInternalAsyncMethodName, FetchResponse, REQUEST_ID_ARG_NAME } from "../ConfigFetcher";
-import { delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, randomUUID, toStringSafe } from "../Utils";
+import { AbortToken, delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, randomUUID, toStringSafe } from "../Utils";
 
 type FetchContext = {
   readonly debugLogger: LoggerWrapper | undefined;
@@ -89,6 +89,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
 
   private httpAgentState: AgentState<http.Agent> | http.Agent | undefined; // undefined indicates disposed state
   private httpsAgentState: AgentState<https.Agent> | https.Agent | undefined; // undefined indicates disposed state
+  private readonly disposeToken: AbortToken;
 
   constructor(options?: INodeHttpConfigFetcherOptions) {
     let httpAgent: http.Agent | undefined, httpAgentFactory: INodeHttpConfigFetcherOptions["httpAgentFactory"] | undefined;
@@ -118,12 +119,16 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
 
     this.httpAgentState = httpAgent ?? new AgentState(httpAgentFactory ?? (options => new http.Agent(options)));
     this.httpsAgentState = httpsAgent ?? new AgentState(httpsAgentFactory ?? (options => new https.Agent(options)));
+    this.disposeToken = new AbortToken();
   }
 
   dispose(): void {
+    this.disposeToken.abort();
+
     const { httpAgentState, httpsAgentState } = this;
     // Release agent objects and factory callbacks so GC can collect them.
     this.httpAgentState = this.httpsAgentState = void 0;
+
     if (httpAgentState instanceof AgentState) {
       httpAgentState.agent?.destroy();
     }
@@ -202,11 +207,11 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     const isHttpsUrl = /^https:/i.test(url);
 
     for (let retryNumber = 0; ; retryNumber++) {
-      const agentStateOrExternalAgent = isHttpsUrl ? this.httpsAgentState : this.httpAgentState;
-      if (!agentStateOrExternalAgent) { // has config fetcher been disposed?
+      if (this.disposeToken.aborted) {
         throw new FetchError("abort");
       }
 
+      const agentStateOrExternalAgent = (isHttpsUrl ? this.httpsAgentState : this.httpAgentState)!;
       const [agentState, agent] = agentStateOrExternalAgent instanceof AgentState
         ? [agentStateOrExternalAgent as AgentState<http.Agent | https.Agent>, agentStateOrExternalAgent.getOrCreateAgent()]
         // eslint-disable-next-line no-sparse-arrays
@@ -302,6 +307,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
   private fetchCoreAsync(
     request: FetchRequest, isCustomUrl: boolean, isHttpsUrl: boolean, agent: http.Agent | https.Agent, context: FetchContext
   ): Promise<FetchResponse> {
+    let unregisterFromDisposeToken: (() => void) | undefined;
     return new Promise<FetchResponse>((resolve, reject) => {
       const { debugLogger, requestId } = context;
       const { url, lastETag, timeoutMs } = request;
@@ -327,7 +333,13 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
         )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${lastETag ?? ""}', Options: ${requestOptionsSafe})`);
       }
 
-      const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, resolve, reject, context))
+      const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, resolve, reject, context));
+
+      unregisterFromDisposeToken = this.disposeToken.registerCallback(
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        typeof clientRequest.abort !== "undefined" ? () => clientRequest.abort() : () => clientRequest.destroy());
+
+      clientRequest
         .on("timeout", () => {
           try {
             clientRequest.destroy();
@@ -337,7 +349,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
         })
         .on("close", () => {
           // eslint-disable-next-line @typescript-eslint/no-deprecated
-          if (typeof clientRequest.aborted !== "undefined" ? clientRequest.aborted : clientRequest.destroyed) {
+          if (typeof clientRequest.abort !== "undefined" ? clientRequest.aborted : clientRequest.destroyed) {
             reject(new (FetchError as FetchErrorCtorInternal)("abort", context.rayId));
           }
         })
@@ -345,7 +357,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
           reject(new (FetchError as FetchErrorCtorInternal)("failure", err, context.rayId));
         })
         .end();
-    });
+    }).finally(() => unregisterFromDisposeToken?.());
   }
 
   protected setRequestHeaders(requestOptions: { headers?: Record<string, number | string | string[]> }, headers: ReadonlyArray<readonly [string, string]>): void {

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -6,7 +6,7 @@ import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { CONNECTIONPOOL_RESET_THRESHOLD_MS, FETCH_RETRY_DELAY_MS, FETCH_RETRY_LIMIT, FetchError, fetchInternalAsyncMethodName, FetchResponse, REQUEST_ID_ARG_NAME } from "../ConfigFetcher";
-import { AbortToken, delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, randomUUID, toStringSafe } from "../Utils";
+import { AbortToken, delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, randomUUID } from "../Utils";
 
 type FetchContext = {
   readonly debugLogger: LoggerWrapper | undefined;
@@ -89,6 +89,12 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
 
   private httpAgentState: AgentState<http.Agent> | http.Agent | undefined; // undefined indicates disposed state
   private httpsAgentState: AgentState<https.Agent> | https.Agent | undefined; // undefined indicates disposed state
+
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly
+  private agentRenewalThresholdMs = CONNECTIONPOOL_RESET_THRESHOLD_MS;
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly
+  private requestRetryDelayMs = FETCH_RETRY_DELAY_MS;
+
   private readonly disposeToken: AbortToken;
 
   constructor(options?: INodeHttpConfigFetcherOptions) {
@@ -198,11 +204,10 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
 
     if (debugLogger) {
       requestId = randomUUID();
-
       debugLogger.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Preparing request...`);
     }
 
-    const { url } = request;
+    const { url, lastETag, timeoutMs } = request;
     const isCustomUrl = !isCdnUrl(url);
     const isHttpsUrl = /^https:/i.test(url);
 
@@ -217,6 +222,20 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
         // eslint-disable-next-line no-sparse-arrays
         : [, agentStateOrExternalAgent];
 
+      const requestOptions = Object.create(null) as (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> };
+      requestOptions.agent = agent;
+      requestOptions.timeout = timeoutMs;
+
+      if (isCustomUrl) {
+        this.setRequestHeaders(requestOptions, request.headers);
+      } else {
+        setRequestHeadersDefault(requestOptions, request.headers);
+      }
+
+      if (lastETag) {
+        (requestOptions.headers ??= {})["If-None-Match"] = lastETag;
+      }
+
       let shouldRenewAgent = false;
 
       if (agentState) {
@@ -230,7 +249,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       try {
-        const fetchResponse = await this.fetchCoreAsync(request, isCustomUrl, isHttpsUrl, agent,
+        const fetchResponse = await this.fetchCoreAsync(isHttpsUrl ? https : http, url, requestOptions,
           { debugLogger, requestId, rayId: void 0 });
 
         if (FetchResponse.prototype.isExpected.call(fetchResponse)) {
@@ -269,7 +288,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
         if (agentState) {
           let numRequestsToSubtract = 1;
           try {
-            if (shouldRenewAgent && agentState.canRenew(CONNECTIONPOOL_RESET_THRESHOLD_MS)) {
+            if (shouldRenewAgent && agentState.canRenew(this.agentRenewalThresholdMs)) {
               const currentAgentState = isHttpsUrl ? this.httpsAgentState : this.httpAgentState;
               if (agentState === currentAgentState) {
                 isHttpsUrl
@@ -298,42 +317,41 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
       }
 
       // Wait a little before trying again.
-      await delay(FETCH_RETRY_DELAY_MS);
+      await delay(this.requestRetryDelayMs);
 
       debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Trying request again...`);
     }
   }
 
   private fetchCoreAsync(
-    request: FetchRequest, isCustomUrl: boolean, isHttpsUrl: boolean, agent: http.Agent | https.Agent, context: FetchContext
+    httpModule: typeof http | typeof https,
+    url: string,
+    requestOptions: (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> },
+    context: FetchContext
   ): Promise<FetchResponse> {
     let unregisterFromDisposeToken: (() => void) | undefined;
     return new Promise<FetchResponse>((resolve, reject) => {
       const { debugLogger, requestId } = context;
-      const { url, lastETag, timeoutMs } = request;
-
-      const requestOptions = Object.create(null) as (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> };
-      requestOptions.agent = agent;
-      requestOptions.timeout = timeoutMs;
-
-      if (isCustomUrl) {
-        this.setRequestHeaders(requestOptions, request.headers);
-      } else {
-        setRequestHeadersDefault(requestOptions, request.headers);
-      }
-
-      if (lastETag) {
-        (requestOptions.headers ??= {})["If-None-Match"] = lastETag;
-      }
+      const timeoutMs = requestOptions.timeout;
 
       if (debugLogger) {
-        const requestOptionsSafe = JSON.stringify({ ...requestOptions, agent: toStringSafe(requestOptions.agent) });
+        let ifNoneMatchHeaderValue: string | number | undefined;
+        const requestHeaders = requestOptions.headers;
+        if (requestHeaders) {
+          for (const key in requestHeaders) {
+            if (hasOwnProperty(requestHeaders, key) && key.toLowerCase() === "if-none-match") {
+              const value = requestHeaders[key];
+              ifNoneMatchHeaderValue = isArray(value) ? value[0] : value;
+              break;
+            }
+          }
+        }
         debugLogger.debug(FormattableLogMessage.from(
-          REQUEST_ID_ARG_NAME, "URL", "IF_NONE_MATCH", "OPTIONS"
-        )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${lastETag ?? ""}', Options: ${requestOptionsSafe})`);
+          REQUEST_ID_ARG_NAME, "URL", "IF_NONE_MATCH"
+        )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${ifNoneMatchHeaderValue ?? ""}')`);
       }
 
-      const clientRequest = (isHttpsUrl ? https : http).get(url, requestOptions, response => this.handleResponse(response, resolve, reject, context));
+      const clientRequest = httpModule.get(url, requestOptions, response => this.handleResponse(response, resolve, reject, context));
 
       unregisterFromDisposeToken = this.disposeToken.registerCallback(
         // eslint-disable-next-line @typescript-eslint/no-deprecated

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -204,7 +204,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     for (let retryNumber = 0; ; retryNumber++) {
       const agentStateOrExternalAgent = isHttpsUrl ? this.httpsAgentState : this.httpAgentState;
       if (!agentStateOrExternalAgent) { // has config fetcher been disposed?
-        throw retryNumber > 0 ? new FetchError("abort") : Error(`${this.constructor.name} object has been disposed.`);
+        throw new FetchError("abort");
       }
 
       const [agentState, agent] = agentStateOrExternalAgent instanceof AgentState

--- a/src/node/NodeHttpConfigFetcher.ts
+++ b/src/node/NodeHttpConfigFetcher.ts
@@ -5,7 +5,7 @@ import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { connectionPoolResetThresholdMs, FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit, requestIdArgName } from "../ConfigFetcher";
+import { CONNECTIONPOOL_RESET_THRESHOLD_MS, FETCH_RETRY_DELAY_MS, FETCH_RETRY_LIMIT, FetchError, fetchInternalAsyncMethodName, FetchResponse, REQUEST_ID_ARG_NAME } from "../ConfigFetcher";
 import { delay, ensureFunctionArg, ensureObjectArg, getMonotonicTimeMs, hasOwnProperty, isArray, randomUUID, toStringSafe } from "../Utils";
 
 type FetchContext = {
@@ -143,7 +143,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
         const { headers } = response;
         const eTagHeaderValue = hasOwnProperty(headers, "etag") ? headers["etag"] : void 0;
         debugLogger.debug(FormattableLogMessage.from(
-          requestIdArgName, "STATUS_CODE", "REASON_PHRASE", "ETAG"
+          REQUEST_ID_ARG_NAME, "STATUS_CODE", "REASON_PHRASE", "ETAG"
         )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
       }
 
@@ -160,7 +160,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
               const body = (fetchResponse as { body: string }).body = Buffer.concat(chunks).toString();
 
               debugLogger?.debug(FormattableLogMessage.from(
-                requestIdArgName, "LENGTH"
+                REQUEST_ID_ARG_NAME, "LENGTH"
               )`[${requestId}] Received body. (Length: ${body.length})`);
 
               resolve(fetchResponse);
@@ -194,7 +194,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
     if (debugLogger) {
       requestId = randomUUID();
 
-      debugLogger.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Preparing request...`);
+      debugLogger.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Preparing request...`);
     }
 
     const { url } = request;
@@ -233,38 +233,38 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
         }
 
         shouldRenewAgent = true;
-        debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Received unexpected status code.`);
+        debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Received unexpected status code.`);
 
-        if (retryNumber >= fetchRetryLimit) {
+        if (retryNumber >= FETCH_RETRY_LIMIT) {
           return fetchResponse;
         }
       } catch (err) {
         if (err instanceof FetchError) {
           switch ((err as FetchError).cause) {
             case "abort":
-              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request aborted.`);
+              debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request aborted.`);
               throw err;
             case "timeout":
               shouldRenewAgent = true;
-              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request timed out.`);
+              debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request timed out.`);
               break;
             case "failure":
               shouldRenewAgent = true;
-              debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request failed.`);
+              debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request failed.`);
               break;
           }
         } else {
           throw err;
         }
 
-        if (retryNumber >= fetchRetryLimit) {
+        if (retryNumber >= FETCH_RETRY_LIMIT) {
           throw err;
         }
       } finally {
         if (agentState) {
           let numRequestsToSubtract = 1;
           try {
-            if (shouldRenewAgent && agentState.canRenew(connectionPoolResetThresholdMs)) {
+            if (shouldRenewAgent && agentState.canRenew(CONNECTIONPOOL_RESET_THRESHOLD_MS)) {
               const currentAgentState = isHttpsUrl ? this.httpsAgentState : this.httpAgentState;
               if (agentState === currentAgentState) {
                 isHttpsUrl
@@ -276,8 +276,8 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
                 numRequestsToSubtract = 2;
 
                 debugLogger?.debug(isHttpsUrl
-                  ? FormattableLogMessage.from(requestIdArgName)`[${requestId}] Renewed https.Agent.`
-                  : FormattableLogMessage.from(requestIdArgName)`[${requestId}] Renewed http.Agent.`);
+                  ? FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Renewed https.Agent.`
+                  : FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Renewed http.Agent.`);
               }
             }
           } finally {
@@ -285,17 +285,17 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
               agent.destroy();
 
               debugLogger?.debug(isHttpsUrl
-                ? FormattableLogMessage.from(requestIdArgName)`[${requestId}] Disposed out-of-use https.Agent.`
-                : FormattableLogMessage.from(requestIdArgName)`[${requestId}] Disposed out-of-use http.Agent.`);
+                ? FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Disposed out-of-use https.Agent.`
+                : FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Disposed out-of-use http.Agent.`);
             }
           }
         }
       }
 
       // Wait a little before trying again.
-      await delay(fetchRetryDelayMs);
+      await delay(FETCH_RETRY_DELAY_MS);
 
-      debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Trying request again...`);
+      debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Trying request again...`);
     }
   }
 
@@ -323,7 +323,7 @@ export class NodeHttpConfigFetcher implements IConfigCatConfigFetcher {
       if (debugLogger) {
         const requestOptionsSafe = JSON.stringify({ ...requestOptions, agent: toStringSafe(requestOptions.agent) });
         debugLogger.debug(FormattableLogMessage.from(
-          requestIdArgName, "URL", "IF_NONE_MATCH", "OPTIONS"
+          REQUEST_ID_ARG_NAME, "URL", "IF_NONE_MATCH", "OPTIONS"
         )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${lastETag ?? ""}', Options: ${requestOptionsSafe})`);
       }
 

--- a/src/node/shims.d.ts
+++ b/src/node/shims.d.ts
@@ -1,9 +1,11 @@
 /* Shim types to be referenced in builds targeting Node.js. (For further explanation, see gulpfile.js.) */
 
 declare module "http" {
+  export interface AgentOptions { }
   export interface Agent { }
 }
 
 declare module "https" {
+  export interface AgentOptions { }
   export interface Agent { }
 }

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -1,8 +1,9 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
-import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, fetchInternalAsyncMethodName, FetchResponse } from "../ConfigFetcher";
+import type { FetchInternalAsyncMethodType, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
+import { delay } from "../Utils";
 
 export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetcher {
   protected constructor(private readonly runsOnServerSide?: boolean) {
@@ -12,62 +13,74 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
     return this[fetchInternalAsyncMethodName](request);
   }
 
-  private async [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
-    logger?.debug("FetchApiConfigFetcher.fetchAsync() called.");
+  // Defined directly on the prototype, see below.
+  private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethodType<FetchApiConfigFetcherBase>;
 
-    let { url } = request;
-    const isCustomUrl = !isCdnUrl(url);
-    const { lastETag, timeoutMs } = request;
+  private async fetchCoreAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
+    for (let retryNumber = 0; ; retryNumber++) {
+      let { url } = request;
+      const isCustomUrl = !isCdnUrl(url);
+      const { lastETag, timeoutMs } = request;
 
-    const requestInit = Object.create(null) as RequestInit & { headers?: [string, string][] };
-    requestInit.method = "GET";
+      const requestInit = Object.create(null) as RequestInit & { headers?: [string, string][] };
+      requestInit.method = "GET";
 
-    if (isCustomUrl) {
-      this.setRequestHeaders(requestInit, request.headers);
-    } else if (this.runsOnServerSide) {
-      setRequestHeadersDefault(requestInit, request.headers);
-    }
+      if (isCustomUrl) {
+        this.setRequestHeaders(requestInit, request.headers);
+      } else if (this.runsOnServerSide) {
+        setRequestHeadersDefault(requestInit, request.headers);
+      }
 
-    if (lastETag) {
-      if (!this.runsOnServerSide) {
+      if (lastETag) {
+        if (!this.runsOnServerSide) {
         // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header,
         // we can transform this query param to the header in our CDN provider.
         // (Explicitly specifying the If-None-Match header would cause an unnecessary CORS OPTIONS request.)
-        url += "&ccetag=" + encodeURIComponent(lastETag);
-      } else {
-        (requestInit.headers ??= []).push(["If-None-Match", lastETag]);
-      }
-    }
-
-    let cleanup: (() => void) | undefined;
-
-    // NOTE: Older Chromium versions (e.g. the one used in our tests) may not support AbortController.
-    if (typeof AbortController === "function") {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-      requestInit.signal = controller.signal;
-      cleanup = () => clearTimeout(timeoutId);
-    }
-
-    try {
-      const response = await fetch(url, requestInit);
-
-      const { status: statusCode, statusText: reasonPhrase } = response;
-      const headers = getResponseHeadersDefault(response);
-      const body = statusCode === 200 ? await response.text() : void 0;
-      return new FetchResponse(statusCode, reasonPhrase, headers, body);
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") {
-        if (requestInit.signal?.aborted) {
-          throw new FetchError("timeout", timeoutMs);
+          url += "&ccetag=" + encodeURIComponent(lastETag);
         } else {
-          throw new FetchError("abort");
+          (requestInit.headers ??= []).push(["If-None-Match", lastETag]);
         }
       }
 
-      throw new FetchError("failure", err);
-    } finally {
-      cleanup?.();
+      let cleanup: (() => void) | undefined;
+
+      // NOTE: Older Chromium versions (e.g. the one used in our tests) may not support AbortController.
+      if (typeof AbortController === "function") {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+        requestInit.signal = controller.signal;
+        cleanup = () => clearTimeout(timeoutId);
+      }
+
+      try {
+        const response = await fetch(url, requestInit);
+
+        const { status: statusCode, statusText: reasonPhrase } = response;
+        const headers = getResponseHeadersDefault(response);
+        const body = statusCode === 200 ? await response.text() : void 0;
+        const fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers, body);
+        if (FetchResponse.prototype.isExpected.call(fetchResponse) || retryNumber >= fetchRetryLimit) {
+          return fetchResponse;
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          if (!requestInit.signal?.aborted) {
+            throw new FetchError("abort");
+          }
+
+          if (retryNumber >= fetchRetryLimit) {
+            throw new FetchError("timeout", timeoutMs);
+          }
+        } else {
+          if (retryNumber >= fetchRetryLimit) {
+            throw new FetchError("failure", err);
+          }
+        }
+      } finally {
+        cleanup?.();
+      }
+
+      await delay(fetchRetryDelayMs);
     }
   }
 
@@ -77,6 +90,12 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
     }
   }
 }
+
+FetchApiConfigFetcherBase.prototype[fetchInternalAsyncMethodName] = function(request: FetchRequest, logger?: LoggerWrapper) {
+  logger?.debug("FetchApiConfigFetcher.fetchAsync() called.");
+
+  return this["fetchCoreAsync"](request, logger);
+};
 
 function setRequestHeadersDefault(requestInit: { headers?: [string, string][] }, headers: ReadonlyArray<readonly [string, string]>): void {
   for (const [name, value] of headers) {

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -2,17 +2,18 @@ import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import type { FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, FetchResponse } from "../ConfigFetcher";
+import { FetchError, fetchInternalAsyncMethodName, FetchResponse } from "../ConfigFetcher";
 
 export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetcher {
-  // eslint-disable-next-line @typescript-eslint/prefer-readonly
-  private logger: LoggerWrapper | null = null;
-
   protected constructor(private readonly runsOnServerSide?: boolean) {
   }
 
-  async fetchAsync(request: FetchRequest): Promise<FetchResponse> {
-    this.logger?.debug("FetchApiConfigFetcher.fetchAsync() called.");
+  fetchAsync(request: FetchRequest): Promise<FetchResponse> {
+    return this[fetchInternalAsyncMethodName](request);
+  }
+
+  private async [fetchInternalAsyncMethodName](request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
+    logger?.debug("FetchApiConfigFetcher.fetchAsync() called.");
 
     let { url } = request;
     const isCustomUrl = !isCdnUrl(url);
@@ -99,21 +100,13 @@ function getResponseHeadersDefault(httpResponse: Response): [string, string][] {
 
 export class ClientSideFetchApiConfigFetcher extends FetchApiConfigFetcherBase {
   private static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
-    return options => {
-      const configFetcher = new ClientSideFetchApiConfigFetcher();
-      configFetcher["logger"] = options.logger;
-      return configFetcher;
-    };
+    return options => new ClientSideFetchApiConfigFetcher();
   }
 }
 
 export class ServerSideFetchApiConfigFetcher extends FetchApiConfigFetcherBase {
   private static getFactory(): (options: OptionsBase) => IConfigCatConfigFetcher {
-    return options => {
-      const configFetcher = new ServerSideFetchApiConfigFetcher();
-      configFetcher["logger"] = options.logger;
-      return configFetcher;
-    };
+    return options => new ServerSideFetchApiConfigFetcher();
   }
 
   constructor() {

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -7,13 +7,16 @@ import { adjustUrlForBrowser, FETCH_RETRY_DELAY_MS, FETCH_RETRY_LIMIT, FetchErro
 import { AbortToken, delay, randomUUID } from "../Utils";
 
 export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetcher {
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly
+  private requestRetryDelayMs = FETCH_RETRY_DELAY_MS;
+
   private readonly disposeToken = new AbortToken();
 
   dispose(): void {
     this.disposeToken.abort();
   }
 
-  protected constructor(private readonly runsOnServerSide?: boolean) {
+  constructor(private readonly runsOnServerSide?: boolean) {
   }
 
   fetchAsync(request: FetchRequest): Promise<FetchResponse> {
@@ -29,19 +32,21 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
 
     if (debugLogger) {
       requestId = randomUUID();
-
       debugLogger.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Preparing request...`);
     }
 
-    const isCustomUrl = !isCdnUrl(request.url);
+    let { url } = request;
+    const isCustomUrl = !isCdnUrl(url);
+    const { lastETag, timeoutMs } = request;
+
+    if (!this.runsOnServerSide) {
+      url = adjustUrlForBrowser(url, request);
+    }
 
     for (let retryNumber = 0; ; retryNumber++) {
       if (this.disposeToken.aborted) {
         throw new FetchError("abort");
       }
-
-      let { url } = request;
-      const { lastETag, timeoutMs } = request;
 
       const requestInit = Object.create(null) as RequestInit & { headers?: [string, string][] };
       requestInit.method = "GET";
@@ -52,12 +57,8 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
         setRequestHeadersDefault(requestInit, request.headers);
       }
 
-      if (lastETag) {
-        if (!this.runsOnServerSide) {
-          url = adjustUrlForBrowser(url, request);
-        } else {
-          (requestInit.headers ??= []).push(["If-None-Match", lastETag]);
-        }
+      if (this.runsOnServerSide && lastETag) {
+        (requestInit.headers ??= []).push(["If-None-Match", lastETag]);
       }
 
       let rayId: string | undefined;
@@ -77,19 +78,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
       }
 
       try {
-        if (debugLogger) {
-          if (this.runsOnServerSide) {
-            debugLogger.debug(FormattableLogMessage.from(
-              REQUEST_ID_ARG_NAME, "URL", "IF_NONE_MATCH"
-            )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${lastETag ?? ""}')`);
-          } else {
-            debugLogger.debug(FormattableLogMessage.from(
-              REQUEST_ID_ARG_NAME, "URL"
-            )`[${requestId}] Sending request... (Url: '${url}')`);
-          }
-        }
-
-        const response = await fetch(url, requestInit);
+        const response = await this.fetchCoreAsync(url, requestInit, requestId, debugLogger);
 
         const { status: statusCode, statusText: reasonPhrase } = response;
 
@@ -147,10 +136,38 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
       }
 
       // Wait a little before trying again.
-      await delay(FETCH_RETRY_DELAY_MS);
+      await delay(this.requestRetryDelayMs);
 
       debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Trying request again...`);
     }
+  }
+
+  private fetchCoreAsync(
+    url: string, requestInit: RequestInit & { headers?: [string, string][] }, requestId: string | undefined, debugLogger: LoggerWrapper | undefined
+  ): Promise<Response> {
+    if (debugLogger) {
+      if (this.runsOnServerSide) {
+        let ifNoneMatchHeaderValue: string | number | undefined;
+        const requestHeaders = requestInit.headers;
+        if (requestHeaders) {
+          for (const [key, value] of requestHeaders) {
+            if (key.toLowerCase() === "if-none-match") {
+              ifNoneMatchHeaderValue = value;
+              break;
+            }
+          }
+        }
+        debugLogger.debug(FormattableLogMessage.from(
+          REQUEST_ID_ARG_NAME, "URL", "IF_NONE_MATCH"
+        )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${ifNoneMatchHeaderValue ?? ""}')`);
+      } else {
+        debugLogger.debug(FormattableLogMessage.from(
+          REQUEST_ID_ARG_NAME, "URL"
+        )`[${requestId}] Sending request... (Url: '${url}')`);
+      }
+    }
+
+    return fetch(url, requestInit);
   }
 
   protected setRequestHeaders(requestInit: { headers?: [string, string][] }, headers: ReadonlyArray<readonly [string, string]>): void {

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -1,6 +1,7 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
+import { logMethodDebug } from "../ConfigCatLogger";
 import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
 import { delay } from "../Utils";
@@ -104,8 +105,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
 }
 
 FetchApiConfigFetcherBase.prototype[fetchInternalAsyncMethodName] = function(request: FetchRequest, logger?: LoggerWrapper) {
-  logger?.debug("FetchApiConfigFetcherBase.fetchAsync() called.");
-
+  logMethodDebug(logger, "FetchApiConfigFetcherBase.fetchAsync");
   return this["fetchWithRetryAsync"](request, logger);
 };
 

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -1,7 +1,7 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
-import type { FetchInternalAsyncMethodType, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
 import { delay } from "../Utils";
 
@@ -14,7 +14,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
   }
 
   // Defined directly on the prototype, see below.
-  private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethodType<FetchApiConfigFetcherBase>;
+  private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethod<FetchApiConfigFetcherBase>;
 
   private async fetchCoreAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
     for (let retryNumber = 0; ; retryNumber++) {
@@ -92,7 +92,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
 }
 
 FetchApiConfigFetcherBase.prototype[fetchInternalAsyncMethodName] = function(request: FetchRequest, logger?: LoggerWrapper) {
-  logger?.debug("FetchApiConfigFetcher.fetchAsync() called.");
+  logger?.debug("FetchApiConfigFetcherBase.fetchAsync() called.");
 
   return this["fetchCoreAsync"](request, logger);
 };

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -37,7 +37,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
 
     for (let retryNumber = 0; ; retryNumber++) {
       if (this.isDisposed) {
-        throw retryNumber > 0 ? new FetchError("abort") : Error(`${this.constructor.name} object has been disposed.`);
+        throw new FetchError("abort");
       }
 
       let { url } = request;

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -69,8 +69,8 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
       if (typeof AbortController === "function") {
         const controller = new AbortController();
         const unregisterFromDisposeToken = this.disposeToken.registerCallback(() => controller.abort());
-        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
         requestInit.signal = controller.signal;
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
         cleanup = () => {
           clearTimeout(timeoutId);
           unregisterFromDisposeToken();

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -3,7 +3,7 @@ import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit, requestIdArgName } from "../ConfigFetcher";
+import { adjustUrlForBrowser, FETCH_RETRY_DELAY_MS, FETCH_RETRY_LIMIT, FetchError, fetchInternalAsyncMethodName, FetchResponse, REQUEST_ID_ARG_NAME } from "../ConfigFetcher";
 import { delay, randomUUID } from "../Utils";
 
 export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetcher {
@@ -30,7 +30,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
     if (debugLogger) {
       requestId = randomUUID();
 
-      debugLogger.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Preparing request...`);
+      debugLogger.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Preparing request...`);
     }
 
     const isCustomUrl = !isCdnUrl(request.url);
@@ -54,10 +54,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
 
       if (lastETag) {
         if (!this.runsOnServerSide) {
-        // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header,
-        // we can transform this query param to the header in our CDN provider.
-        // (Explicitly specifying the If-None-Match header would cause an unnecessary CORS OPTIONS request.)
-          url += "&ccetag=" + encodeURIComponent(lastETag);
+          url = adjustUrlForBrowser(url, request);
         } else {
           (requestInit.headers ??= []).push(["If-None-Match", lastETag]);
         }
@@ -79,11 +76,11 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
         if (debugLogger) {
           if (this.runsOnServerSide) {
             debugLogger.debug(FormattableLogMessage.from(
-              requestIdArgName, "URL", "IF_NONE_MATCH"
+              REQUEST_ID_ARG_NAME, "URL", "IF_NONE_MATCH"
             )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${lastETag ?? ""}')`);
           } else {
             debugLogger.debug(FormattableLogMessage.from(
-              requestIdArgName, "URL"
+              REQUEST_ID_ARG_NAME, "URL"
             )`[${requestId}] Sending request... (Url: '${url}')`);
           }
         }
@@ -95,7 +92,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
         if (debugLogger) {
           const eTagHeaderValue = response.headers.get("ETag");
           debugLogger.debug(FormattableLogMessage.from(
-            requestIdArgName, "STATUS_CODE", "REASON_PHRASE", "ETAG"
+            REQUEST_ID_ARG_NAME, "STATUS_CODE", "REASON_PHRASE", "ETAG"
           )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
         }
 
@@ -108,7 +105,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
           body = (fetchResponse as { body: string }).body = await response.text();
 
           debugLogger?.debug(FormattableLogMessage.from(
-            requestIdArgName, "LENGTH"
+            REQUEST_ID_ARG_NAME, "LENGTH"
           )`[${requestId}] Received body. (Length: ${body.length})`);
         }
 
@@ -116,28 +113,28 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
           return fetchResponse;
         }
 
-        debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Received unexpected status code.`);
+        debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Received unexpected status code.`);
 
-        if (retryNumber >= fetchRetryLimit) {
+        if (retryNumber >= FETCH_RETRY_LIMIT) {
           return fetchResponse;
         }
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") {
           if (!requestInit.signal?.aborted) {
-            debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request aborted.`);
+            debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request aborted.`);
 
             throw new (FetchError as FetchErrorCtorInternal)("abort", rayId);
           }
 
-          debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request timed out.`);
+          debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request timed out.`);
 
-          if (retryNumber >= fetchRetryLimit) {
+          if (retryNumber >= FETCH_RETRY_LIMIT) {
             throw new (FetchError as FetchErrorCtorInternal)("timeout", timeoutMs, rayId);
           }
         } else {
-          debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request failed.`);
+          debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request failed.`);
 
-          if (retryNumber >= fetchRetryLimit) {
+          if (retryNumber >= FETCH_RETRY_LIMIT) {
             throw new (FetchError as FetchErrorCtorInternal)("failure", err, rayId);
           }
         }
@@ -146,9 +143,9 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
       }
 
       // Wait a little before trying again.
-      await delay(fetchRetryDelayMs);
+      await delay(FETCH_RETRY_DELAY_MS);
 
-      debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Trying request again...`);
+      debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Trying request again...`);
     }
   }
 

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -1,10 +1,10 @@
 import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
-import { logMethodDebug } from "../ConfigCatLogger";
+import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
-import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit } from "../ConfigFetcher";
-import { delay } from "../Utils";
+import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit, requestIdArgName } from "../ConfigFetcher";
+import { delay, randomUUID } from "../Utils";
 
 export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetcher {
   private isDisposed = false;
@@ -23,7 +23,16 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
   // Defined directly on the prototype, see below.
   private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethod<FetchApiConfigFetcherBase>;
 
-  private async fetchWithRetryAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
+  private async fetchWithRetryAsync(request: FetchRequest, logger: LoggerWrapper | undefined): Promise<FetchResponse> {
+    const debugLogger = logger?.ifDebug;
+    let requestId: string | undefined;
+
+    if (debugLogger) {
+      requestId = randomUUID();
+
+      debugLogger.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Preparing request...`);
+    }
+
     const isCustomUrl = !isCdnUrl(request.url);
 
     for (let retryNumber = 0; ; retryNumber++) {
@@ -65,25 +74,66 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
       }
 
       try {
+        if (debugLogger) {
+          if (this.runsOnServerSide) {
+            debugLogger.debug(FormattableLogMessage.from(
+              requestIdArgName, "URL", "IF_NONE_MATCH"
+            )`[${requestId}] Sending request... (Url: '${url}', If-None-Match: '${lastETag ?? ""}')`);
+          } else {
+            debugLogger.debug(FormattableLogMessage.from(
+              requestIdArgName, "URL"
+            )`[${requestId}] Sending request... (Url: '${url}')`);
+          }
+        }
+
         const response = await fetch(url, requestInit);
 
         const { status: statusCode, statusText: reasonPhrase } = response;
+
+        if (debugLogger) {
+          const eTagHeaderValue = response.headers.get("ETag");
+          debugLogger.debug(FormattableLogMessage.from(
+            requestIdArgName, "STATUS_CODE", "REASON_PHRASE", "ETAG"
+          )`[${requestId}] Received headers. (StatusCode: ${statusCode}, ReasonPhrase: '${reasonPhrase}', ETag: '${eTagHeaderValue ?? ""}')`);
+        }
+
         const headers = getResponseHeadersDefault(response);
-        const body = statusCode === 200 ? await response.text() : void 0;
+
+        let body: string | undefined;
+        if (statusCode === 200) {
+          body = await response.text();
+
+          debugLogger?.debug(FormattableLogMessage.from(
+            requestIdArgName, "LENGTH"
+          )`[${requestId}] Received body. (Length: ${body.length})`);
+        }
+
         const fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers, body);
-        if (FetchResponse.prototype.isExpected.call(fetchResponse) || retryNumber >= fetchRetryLimit) {
+        if (FetchResponse.prototype.isExpected.call(fetchResponse)) {
+          return fetchResponse;
+        }
+
+        debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Received unexpected status code.`);
+
+        if (retryNumber >= fetchRetryLimit) {
           return fetchResponse;
         }
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") {
           if (!requestInit.signal?.aborted) {
+            debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request aborted.`);
+
             throw new FetchError("abort");
           }
+
+          debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request timed out.`);
 
           if (retryNumber >= fetchRetryLimit) {
             throw new FetchError("timeout", timeoutMs);
           }
         } else {
+          debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request failed.`);
+
           if (retryNumber >= fetchRetryLimit) {
             throw new FetchError("failure", err);
           }
@@ -94,6 +144,8 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
 
       // Wait a little before trying again.
       await delay(fetchRetryDelayMs);
+
+      debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Trying request again...`);
     }
   }
 

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -4,13 +4,13 @@ import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
 import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { adjustUrlForBrowser, FETCH_RETRY_DELAY_MS, FETCH_RETRY_LIMIT, FetchError, fetchInternalAsyncMethodName, FetchResponse, REQUEST_ID_ARG_NAME } from "../ConfigFetcher";
-import { delay, randomUUID } from "../Utils";
+import { AbortToken, delay, randomUUID } from "../Utils";
 
 export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetcher {
-  private isDisposed = false;
+  private readonly disposeToken = new AbortToken();
 
   dispose(): void {
-    this.isDisposed = true;
+    this.disposeToken.abort();
   }
 
   protected constructor(private readonly runsOnServerSide?: boolean) {
@@ -36,7 +36,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
     const isCustomUrl = !isCdnUrl(request.url);
 
     for (let retryNumber = 0; ; retryNumber++) {
-      if (this.isDisposed) {
+      if (this.disposeToken.aborted) {
         throw new FetchError("abort");
       }
 
@@ -67,9 +67,13 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
       // NOTE: Older Chromium versions (e.g. the one used in our tests) may not support AbortController.
       if (typeof AbortController === "function") {
         const controller = new AbortController();
+        const unregisterFromDisposeToken = this.disposeToken.registerCallback(() => controller.abort());
         const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
         requestInit.signal = controller.signal;
-        cleanup = () => clearTimeout(timeoutId);
+        cleanup = () => {
+          clearTimeout(timeoutId);
+          unregisterFromDisposeToken();
+        };
       }
 
       try {
@@ -120,7 +124,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
         }
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") {
-          if (!requestInit.signal?.aborted) {
+          if (!requestInit.signal?.aborted || this.disposeToken.aborted) {
             debugLogger?.debug(FormattableLogMessage.from(REQUEST_ID_ARG_NAME)`[${requestId}] Request aborted.`);
 
             throw new (FetchError as FetchErrorCtorInternal)("abort", rayId);

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -6,6 +6,12 @@ import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDela
 import { delay } from "../Utils";
 
 export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetcher {
+  private isDisposed = false;
+
+  dispose(): void {
+    this.isDisposed = true;
+  }
+
   protected constructor(private readonly runsOnServerSide?: boolean) {
   }
 
@@ -16,10 +22,15 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
   // Defined directly on the prototype, see below.
   private [fetchInternalAsyncMethodName]!: FetchInternalAsyncMethod<FetchApiConfigFetcherBase>;
 
-  private async fetchCoreAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
+  private async fetchWithRetryAsync(request: FetchRequest, logger?: LoggerWrapper): Promise<FetchResponse> {
+    const isCustomUrl = !isCdnUrl(request.url);
+
     for (let retryNumber = 0; ; retryNumber++) {
+      if (this.isDisposed) {
+        throw retryNumber > 0 ? new FetchError("abort") : Error(`${this.constructor.name} object has been disposed.`);
+      }
+
       let { url } = request;
-      const isCustomUrl = !isCdnUrl(url);
       const { lastETag, timeoutMs } = request;
 
       const requestInit = Object.create(null) as RequestInit & { headers?: [string, string][] };
@@ -80,6 +91,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
         cleanup?.();
       }
 
+      // Wait a little before trying again.
       await delay(fetchRetryDelayMs);
     }
   }
@@ -94,7 +106,7 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
 FetchApiConfigFetcherBase.prototype[fetchInternalAsyncMethodName] = function(request: FetchRequest, logger?: LoggerWrapper) {
   logger?.debug("FetchApiConfigFetcherBase.fetchAsync() called.");
 
-  return this["fetchCoreAsync"](request, logger);
+  return this["fetchWithRetryAsync"](request, logger);
 };
 
 function setRequestHeadersDefault(requestInit: { headers?: [string, string][] }, headers: ReadonlyArray<readonly [string, string]>): void {

--- a/src/shared/FetchApiConfigFetcher.ts
+++ b/src/shared/FetchApiConfigFetcher.ts
@@ -2,7 +2,7 @@ import type { OptionsBase } from "../ConfigCatClientOptions";
 import { isCdnUrl } from "../ConfigCatClientOptions";
 import type { LoggerWrapper } from "../ConfigCatLogger";
 import { FormattableLogMessage, logMethodDebug } from "../ConfigCatLogger";
-import type { FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
+import type { FetchErrorCtorInternal, FetchInternalAsyncMethod, FetchRequest, IConfigCatConfigFetcher } from "../ConfigFetcher";
 import { FetchError, fetchInternalAsyncMethodName, FetchResponse, fetchRetryDelayMs, fetchRetryLimit, requestIdArgName } from "../ConfigFetcher";
 import { delay, randomUUID } from "../Utils";
 
@@ -63,6 +63,8 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
         }
       }
 
+      let rayId: string | undefined;
+
       let cleanup: (() => void) | undefined;
 
       // NOTE: Older Chromium versions (e.g. the one used in our tests) may not support AbortController.
@@ -98,17 +100,18 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
         }
 
         const headers = getResponseHeadersDefault(response);
+        const fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers);
+        rayId = fetchResponse["rayId"];
 
         let body: string | undefined;
         if (statusCode === 200) {
-          body = await response.text();
+          body = (fetchResponse as { body: string }).body = await response.text();
 
           debugLogger?.debug(FormattableLogMessage.from(
             requestIdArgName, "LENGTH"
           )`[${requestId}] Received body. (Length: ${body.length})`);
         }
 
-        const fetchResponse = new FetchResponse(statusCode, reasonPhrase, headers, body);
         if (FetchResponse.prototype.isExpected.call(fetchResponse)) {
           return fetchResponse;
         }
@@ -123,19 +126,19 @@ export abstract class FetchApiConfigFetcherBase implements IConfigCatConfigFetch
           if (!requestInit.signal?.aborted) {
             debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request aborted.`);
 
-            throw new FetchError("abort");
+            throw new (FetchError as FetchErrorCtorInternal)("abort", rayId);
           }
 
           debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request timed out.`);
 
           if (retryNumber >= fetchRetryLimit) {
-            throw new FetchError("timeout", timeoutMs);
+            throw new (FetchError as FetchErrorCtorInternal)("timeout", timeoutMs, rayId);
           }
         } else {
           debugLogger?.debug(FormattableLogMessage.from(requestIdArgName)`[${requestId}] Request failed.`);
 
           if (retryNumber >= fetchRetryLimit) {
-            throw new FetchError("failure", err);
+            throw new (FetchError as FetchErrorCtorInternal)("failure", err, rayId);
           }
         }
       } finally {

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -453,6 +453,7 @@ describe("Options", () => {
     "sdkKey": ${JSON.stringify(options.sdkKey)},
     "clientVersion": ${JSON.stringify(options.clientVersion)},
     "configFetcher": "[object Object]",
+    "ownsConfigFetcher": ${JSON.stringify(options.ownsConfigFetcher)},
     "dataGovernance": ${JSON.stringify(options.dataGovernance)},
     "baseUrl": ${JSON.stringify(options.baseUrl)},
     "hooks": "[object Object]",

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -31,7 +31,8 @@ describe("Options", () => {
 
     assert.equal("APIKEY", options.sdkKey);
     assert.equal(30000, options.requestTimeoutMs);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json?sdk=common/m-1.0.0", options.getUrl());
+    assert.equal("common/m-1.0.0", options.clientVersion);
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json", options.getUrl());
   });
 
   it("ManualPollOptions initialization With parameters works", () => {
@@ -51,7 +52,8 @@ describe("Options", () => {
     assert.equal(fakeLogger, options.logger["logger"]);
     assert.equal("APIKEY", options.sdkKey);
     assert.equal(10, options.requestTimeoutMs);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json?sdk=common/m-1.0.0", options.getUrl());
+    assert.equal("common/m-1.0.0", options.clientVersion);
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json", options.getUrl());
   });
 
   it("ManualPollOptions initialization With 'baseUrl' Should create an instance with custom baseUrl", () => {
@@ -59,8 +61,9 @@ describe("Options", () => {
     const options = createManualPollOptions("APIKEY", { baseUrl: "https://mycdn.example.org" }, kernel);
 
     assert.isDefined(options);
-    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v6.json?sdk=common/m-1.0.0", options.getUrl());
-    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json?sdk=common/m-1.0.0", options.getUrl());
+    assert.equal("common/m-1.0.0", options.clientVersion);
+    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v6.json", options.getUrl());
+    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json", options.getUrl());
   });
 
   it("AutoPollOptions initialization With -1 requestTimeoutMs ShouldThrowError", () => {
@@ -76,7 +79,8 @@ describe("Options", () => {
     assert.isTrue(options.logger instanceof LoggerWrapper);
     assert.isTrue(options.logger["logger"] instanceof ConfigCatConsoleLogger);
     assert.equal("APIKEY", options.sdkKey);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json?sdk=common/a-1.0.0", options.getUrl());
+    assert.equal("common/a-1.0.0", options.clientVersion);
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json", options.getUrl());
     assert.equal(60, options.pollIntervalSeconds);
     assert.equal(30000, options.requestTimeoutMs);
     assert.isDefined(options.cache);
@@ -98,7 +102,8 @@ describe("Options", () => {
     assert.isDefined(options);
     assert.equal(fakeLogger, options.logger["logger"]);
     assert.equal("APIKEY", options.sdkKey);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json?sdk=common/a-1.0.0", options.getUrl());
+    assert.equal("common/a-1.0.0", options.clientVersion);
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json", options.getUrl());
     assert.equal(59, options.pollIntervalSeconds);
     assert.equal(20, options.requestTimeoutMs);
   });
@@ -152,8 +157,9 @@ describe("Options", () => {
     const options = createAutoPollOptions("APIKEY", { baseUrl: "https://mycdn.example.org" }, kernel);
 
     assert.isDefined(options);
-    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v6.json?sdk=common/a-1.0.0", options.getUrl());
-    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json?sdk=common/a-1.0.0", options.getUrl());
+    assert.equal("common/a-1.0.0", options.clientVersion);
+    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v6.json", options.getUrl());
+    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json", options.getUrl());
   });
 
   it("AutoPollOptions initialization With NaN 'maxInitWaitTimeSeconds' ShouldThrowError", () => {
@@ -201,7 +207,8 @@ describe("Options", () => {
     const options = createLazyLoadOptions("APIKEY", void 0, kernel);
     assert.isDefined(options);
     assert.equal("APIKEY", options.sdkKey);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json?sdk=common/l-1.0.0", options.getUrl());
+    assert.equal("common/l-1.0.0", options.clientVersion);
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json", options.getUrl());
     assert.equal(60, options.cacheTimeToLiveSeconds);
     assert.equal(30000, options.requestTimeoutMs);
   });
@@ -223,7 +230,8 @@ describe("Options", () => {
     assert.isDefined(options);
     assert.equal(fakeLogger, options.logger["logger"]);
     assert.equal("APIKEY", options.sdkKey);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json?sdk=common/l-1.0.0", options.getUrl());
+    assert.equal("common/l-1.0.0", options.clientVersion);
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json", options.getUrl());
     assert.equal(59, options.cacheTimeToLiveSeconds);
     assert.equal(20, options.requestTimeoutMs);
   });
@@ -252,8 +260,9 @@ describe("Options", () => {
     const options = createLazyLoadOptions("APIKEY", { baseUrl: "https://mycdn.example.org" }, kernel);
 
     assert.isDefined(options);
-    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v6.json?sdk=common/l-1.0.0", options.getUrl());
-    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json?sdk=common/l-1.0.0", options.getUrl());
+    assert.equal("common/l-1.0.0", options.clientVersion);
+    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v6.json", options.getUrl());
+    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v6.json", options.getUrl());
   });
 
   it("Options initialization With 'defaultCacheFactory' Should set option cache to passed instance", () => {

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -653,7 +653,7 @@ describe("ConfigCatClient", () => {
 
       const configFetchDelay = maxInitWaitTimeSeconds * 1000 / 4;
       const configFetcher = new FakeConfigFetcherBase(null, configFetchDelay, () =>
-        statusCode ? { statusCode, reasonPhrase: "x" } : (() => { throw "network error"; })());
+        statusCode ? { statusCode, reasonPhrase: "x" } as FetchResponse : (() => { throw "network error"; })());
 
       const configCatKernel = createKernel({ configFetcherFactory: () => configFetcher });
       const options: AutoPollOptions = createAutoPollOptions("APIKEY", { maxInitWaitTimeSeconds }, configCatKernel);

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -1032,7 +1032,7 @@ describe("ConfigCatClient", () => {
     client.dispose();
     assert.equal(configFetcher.calledTimes, 0);
     setTimeout(() => {
-      assert.equal(configFetcher.calledTimes, 1);
+      assert.equal(configFetcher.calledTimes, 0);
       client.dispose();
       done();
     }, 4000);

--- a/test/ConfigCatConfigFetcherTests.ts
+++ b/test/ConfigCatConfigFetcherTests.ts
@@ -2,8 +2,6 @@ import { assert, expect } from "chai";
 import { FakeConfigFetcherWithTwoKeys, FakeLogger } from "./helpers/fakes";
 import { platform } from "./helpers/platform";
 import { FetchRequest, FetchResponse, FormattableLogMessage, IConfigCatConfigFetcher } from "#lib";
-import { ConfigCatClient } from "#lib/ConfigCatClient";
-import { OptionsBase } from "#lib/ConfigCatClientOptions";
 
 describe("ConfigCatConfigFetcherTests", () => {
 
@@ -88,12 +86,6 @@ describe("ConfigCatConfigFetcherTests", () => {
 
     assert.strictEqual(configFetcherRequests.length, 1);
     assert.isUndefined(configFetcherRequests[0].lastETag);
-
-    // TODO: Remove this as soon as we update the CDN CORS settings (see also https://trello.com/c/RSGwVoqC)
-    const clientVersion: string = (((client as ConfigCatClient)["options"]) as OptionsBase)["clientVersion"];
-    if (clientVersion.includes("ConfigCat-UnifiedJS-Browser") || clientVersion.includes("ConfigCat-UnifiedJS-ChromiumExtension")) {
-      return;
-    }
 
     const errors = fakeLogger.events.filter(([, eventId]) => eventId === 1100);
     assert.strictEqual(errors.length, 1);

--- a/test/ConfigCatConfigFetcherTests.ts
+++ b/test/ConfigCatConfigFetcherTests.ts
@@ -1,7 +1,12 @@
 import { assert, expect } from "chai";
-import { FakeConfigFetcherWithTwoKeys, FakeLogger } from "./helpers/fakes";
+import { createManualPollOptions, FakeConfigFetcherWithTwoKeys, FakeLogger } from "./helpers/fakes";
 import { platform } from "./helpers/platform";
 import { FetchRequest, FetchResponse, FormattableLogMessage, IConfigCatConfigFetcher } from "#lib";
+import { isCdnUrl } from "#lib/ConfigCatClientOptions";
+import { adjustUrlForBrowser, CONFIGCAT_USER_AGENT_HEADER_NAME, ETAG_QUERYPARAM_NAME, SDK_QUERYPARAM_NAME, USER_AGENT_HEADER_NAME } from "#lib/ConfigFetcher";
+
+const testSdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g";
+const testETag = "W/\"123\"";
 
 describe("ConfigCatConfigFetcherTests", () => {
 
@@ -106,4 +111,98 @@ describe("ConfigCatConfigFetcherTests", () => {
     client.dispose();
   });
 
+  for (const [queryAndFragment, sdkKey, etag, useAbsoluteUrl] of <[string, string, string | undefined, boolean][]>[
+    ["", testSdkKey, testETag, false],
+    ["", testSdkKey, testETag, true],
+    ["", "configcat%2dsdk%2d1/PKDVCLf%2dHq%2dh%2dkCzMp%2dL7Q/u28_1qNyZ0Wz%2dldYHIU7%2dg", testETag, false],
+    ["", "configcat%2dsdk%2d1/PKDVCLf%2dHq%2dh%2dkCzMp%2dL7Q/u28_1qNyZ0Wz%2dldYHIU7%2dg", testETag, true],
+    ["", testSdkKey, null, false],
+    ["", testSdkKey, null, true],
+    ["?", testSdkKey, testETag, false],
+    ["?", testSdkKey, testETag, true],
+    ["?", testSdkKey, null, false],
+    ["?", testSdkKey, null, true],
+    ["?ccetag=123", testSdkKey, testETag, false],
+    ["?ccetag=123", testSdkKey, testETag, true],
+    ["?ccetag=123#f", testSdkKey, testETag, false],
+    ["?ccetag=123#f", testSdkKey, testETag, true],
+    ["#f", testSdkKey, testETag, false],
+    ["#f", testSdkKey, testETag, true],
+  ]) {
+    it(`AdjustUriForBrowser should work - queryAndFragment: ${queryAndFragment} | sdkKey: ${sdkKey} | etag: ${etag} | useAbsoluteUrl: ${useAbsoluteUrl}`, () => {
+      // Arrange
+
+      const options = createManualPollOptions(sdkKey);
+
+      let url = options.getUrl() + queryAndFragment;
+      const parsedAbsoluteUrl = new URL(url);
+
+      if (!useAbsoluteUrl) {
+        const index = url.indexOf("://");
+        url = url.substring(url.indexOf("/", index + 3));
+      }
+
+      const requestHeaders: [string, string][] = [
+        [USER_AGENT_HEADER_NAME, options.clientVersion],
+        [CONFIGCAT_USER_AGENT_HEADER_NAME, options.clientVersion],
+      ];
+      const fetchRequest = new FetchRequest(url, etag, requestHeaders, Infinity);
+
+      // Act
+
+      const adjustedUrl = adjustUrlForBrowser(url, fetchRequest);
+
+      // Assert
+
+      const parsedAdjustedUrl = new URL(useAbsoluteUrl ? adjustedUrl : "https://x" + adjustedUrl);
+
+      assert.strictEqual(parsedAdjustedUrl.pathname, parsedAbsoluteUrl.pathname);
+
+      const normalizedUserAgentHeaderName = USER_AGENT_HEADER_NAME.toLowerCase();
+      const expectedUserAgentHeaderValue = fetchRequest.headers.find(([key]) => key.toLowerCase() === normalizedUserAgentHeaderName)![1];
+
+      const expectedQueryParams: [string, string][] = [];
+      expectedQueryParams.push([SDK_QUERYPARAM_NAME, expectedUserAgentHeaderValue]);
+      if (etag || parsedAbsoluteUrl.searchParams.size) {
+        expectedQueryParams.push([ETAG_QUERYPARAM_NAME, etag ?? ""]);
+      }
+      parsedAbsoluteUrl.searchParams.forEach((value, key) => expectedQueryParams.push([key, value]));
+
+      const actualQueryParams: [string, string][] = [];
+      parsedAdjustedUrl.searchParams.forEach((value, key) => actualQueryParams.push([key, value]));
+
+      assert.deepEqual(actualQueryParams, expectedQueryParams);
+
+      assert.strictEqual(parsedAdjustedUrl.hash, "");
+    });
+  }
+
+  for (const [url, expectedResult] of <[string, boolean][]>[
+    ["/", false],
+    ["/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", false],
+    ["file:///configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", false],
+    ["http://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", true],
+    ["https://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", true],
+    ["https://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json?x=/configcat-proxy/", true],
+    ["https://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json?x#/configcat-proxy/", true],
+    ["https://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json#/configcat-proxy/", true],
+    ["https://cdn-global.configcat.com/configuration%2dfiles/configcat%2dsdk%2d1/PKDVCLf%2dHq%2dh%2dkCzMp%2dL7Q/u28_1qNyZ0Wz%2dldYHIU7%2dg/config_v6.json", true],
+    ["https://cdn-global.configcat.com./configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", true],
+    ["https://cdn-global.configcat.com/configcat-proxy/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", false],
+    ["https://cdn-global.configcat.com/configcat%2dproxy/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", false],
+    ["https://cdn-global.configcat.com/configuration-files/configcat-proxy/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", false],
+    ["https://cdn-global.configcat.com/configuration-files/configcat%2Dproxy/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json?x", false],
+  ]) {
+    it(`IsCdnUri should work - url: ${url}`, () => {
+      // Arrange
+
+      // Act
+
+      const actualResult = isCdnUrl(url);
+
+      // Assert
+
+      assert.strictEqual(actualResult, expectedResult);
+    });
+  }
 });

--- a/test/ConfigCatConfigFetcherTests.ts
+++ b/test/ConfigCatConfigFetcherTests.ts
@@ -2,13 +2,65 @@ import { assert, expect } from "chai";
 import { createManualPollOptions, FakeConfigFetcherWithTwoKeys, FakeLogger } from "./helpers/fakes";
 import { platform } from "./helpers/platform";
 import { FetchRequest, FetchResponse, FormattableLogMessage, IConfigCatConfigFetcher } from "#lib";
+import { ConfigCatClient } from "#lib/ConfigCatClient";
 import { isCdnUrl } from "#lib/ConfigCatClientOptions";
-import { adjustUrlForBrowser, CONFIGCAT_USER_AGENT_HEADER_NAME, ETAG_QUERYPARAM_NAME, SDK_QUERYPARAM_NAME, USER_AGENT_HEADER_NAME } from "#lib/ConfigFetcher";
+import { adjustUrlForBrowser, ETAG_QUERYPARAM_NAME, getRequestHeaders, SDK_QUERYPARAM_NAME, USER_AGENT_HEADER_NAME } from "#lib/ConfigFetcher";
+import { ManualPollConfigService } from "#lib/ManualPollConfigService";
 
 const testSdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g";
 const testETag = "W/\"123\"";
 
 describe("ConfigCatConfigFetcherTests", () => {
+  it("Internal config fetcher should be disposed", () => {
+    // Arrange
+
+    const client = platform().createClientWithManualPoll(
+      "test-67890123456789012/1234567890123456789012"
+    ) as ConfigCatClient;
+
+    const configService = client["configService"] as ManualPollConfigService;
+
+    const configFetcher = configService["configFetcher"];
+
+    let isDisposed = false;
+    const originalDispose = configFetcher.dispose;
+    configFetcher.dispose = function() {
+      isDisposed = true;
+      originalDispose?.call(this);
+    };
+
+    // Act
+
+    client.dispose();
+
+    // Assert
+
+    assert.isTrue(isDisposed);
+  });
+
+  it("External config fetcher should not be disposed", () => {
+    // Arrange
+
+    let isDisposed = false;
+
+    const configFetcher = new class implements IConfigCatConfigFetcher {
+      fetchAsync(request: FetchRequest): never { throw Error("Not implemented"); }
+      dispose(): void { isDisposed = true; }
+    }();
+
+    const client = platform().createClientWithManualPoll(
+      "test-67890123456789012/1234567890123456789012",
+      { configFetcher }
+    );
+
+    // Act
+
+    client.dispose();
+
+    // Assert
+
+    assert.isFalse(isDisposed);
+  });
 
   it("Custom config fetcher - Success", async () => {
     // Arrange
@@ -142,10 +194,7 @@ describe("ConfigCatConfigFetcherTests", () => {
         url = url.substring(url.indexOf("/", index + 3));
       }
 
-      const requestHeaders: [string, string][] = [
-        [USER_AGENT_HEADER_NAME, options.clientVersion],
-        [CONFIGCAT_USER_AGENT_HEADER_NAME, options.clientVersion],
-      ];
+      const requestHeaders = getRequestHeaders(options.clientVersion);
       const fetchRequest = new FetchRequest(url, etag, requestHeaders, Infinity);
 
       // Act

--- a/test/ConfigCatConfigFetcherTests.ts
+++ b/test/ConfigCatConfigFetcherTests.ts
@@ -50,6 +50,8 @@ describe("ConfigCatConfigFetcherTests", () => {
 
     assert.strictEqual(configFetcherRequests.length, 2);
     assert.strictEqual(configFetcherRequests[1].lastETag, eTag);
+
+    client.dispose();
   });
 
   it("Custom config fetcher - Failure", async () => {
@@ -108,6 +110,8 @@ describe("ConfigCatConfigFetcherTests", () => {
     assert.equal(actualRayId, rayId);
 
     expect(error.toString()).to.contain(rayId);
+
+    client.dispose();
   });
 
 });

--- a/test/ConfigServiceBaseTests.ts
+++ b/test/ConfigServiceBaseTests.ts
@@ -40,7 +40,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson });
+      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse);
 
     let callNo = 1;
 
@@ -82,7 +82,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson });
+      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse);
 
     let callNo = 1;
 
@@ -122,13 +122,13 @@ describe("ConfigServiceBaseTests", () => {
 
     const pc: ProjectConfig = createProjectConfig();
     const fr: FetchResult = createFetchResult();
-    let currentResp: FetchResponse = { statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson };
+    let currentResp = { statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse;
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
       .callback(() => {
         const result = Promise.resolve(currentResp);
-        currentResp = { statusCode: 500, reasonPhrase: "Internal Server Error" };
+        currentResp = { statusCode: 500, reasonPhrase: "Internal Server Error" } as FetchResponse;
         return result;
       });
 
@@ -182,7 +182,7 @@ describe("ConfigServiceBaseTests", () => {
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
       .callback(() => new Promise(resolve =>
-        setTimeout(() => resolve({ statusCode: 200, reasonPhrase: "OK", eTag: frNew.config.httpETag, body: frNew.config.configJson }), 100)));
+        setTimeout(() => resolve({ statusCode: 200, reasonPhrase: "OK", eTag: frNew.config.httpETag, body: frNew.config.configJson } as FetchResponse), 100)));
 
     const options = createAutoPollOptions(
       "APIKEY",
@@ -228,7 +228,7 @@ describe("ConfigServiceBaseTests", () => {
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
       .callback(() => new Promise(resolve =>
-        setTimeout(() => resolve({ statusCode: 200, reasonPhrase: "OK", eTag: frNew.config.httpETag, body: frNew.config.configJson }), 100)));
+        setTimeout(() => resolve({ statusCode: 200, reasonPhrase: "OK", eTag: frNew.config.httpETag, body: frNew.config.configJson } as FetchResponse), 100)));
 
     const options = createAutoPollOptions(
       "APIKEY",
@@ -273,7 +273,7 @@ describe("ConfigServiceBaseTests", () => {
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
       .callback(() => new Promise(resolve =>
-        setTimeout(() => resolve({ statusCode: 500, reasonPhrase: "Internal Server Error" }), 2000)));
+        setTimeout(() => resolve({ statusCode: 500, reasonPhrase: "Internal Server Error" } as FetchResponse), 2000)));
 
     const options = createAutoPollOptions(
       "APIKEY",
@@ -374,7 +374,7 @@ describe("ConfigServiceBaseTests", () => {
       const fr: FetchResult = createFetchResult();
       const fetcherMock = new Mock<IConfigFetcher>()
         .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-        .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson });
+        .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse);
 
       const options = createAutoPollOptions(
         "APIKEY",
@@ -455,7 +455,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson });
+      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse);
 
     const cacheMock = new Mock<IConfigCache>()
       .setup(m => m.get(It.IsAny<string>()))
@@ -528,7 +528,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson });
+      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse);
 
     const cacheMock = new Mock<IConfigCache>()
       .setup(m => m.get(It.IsAny<string>()))
@@ -568,7 +568,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson });
+      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse);
 
     const cacheMock = new Mock<IConfigCache>(asyncInjectorServiceConfig)
       .setup(m => m.get(It.IsAny<string>()))
@@ -613,7 +613,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson });
+      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse);
 
     const options = createAutoPollOptions(
       "APIKEY",
@@ -657,7 +657,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson });
+      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse);
 
     const options = createAutoPollOptions(
       "APIKEY",
@@ -703,7 +703,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson });
+      .returnsAsync({ statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse);
 
     const options = createLazyLoadOptions(
       "APIKEY",
@@ -743,7 +743,7 @@ describe("ConfigServiceBaseTests", () => {
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
       .callback(async () => {
         await delay(500);
-        return { statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson };
+        return { statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse;
       });
 
     const options = createLazyLoadOptions(
@@ -781,7 +781,7 @@ describe("ConfigServiceBaseTests", () => {
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
       .callback(async () => {
         await delay(100);
-        return { statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson };
+        return { statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse;
       });
 
     const options = createManualPollOptions(
@@ -817,7 +817,7 @@ describe("ConfigServiceBaseTests", () => {
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
       .callback(async () => {
         await delay(100);
-        return { statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson };
+        return { statusCode: 200, reasonPhrase: "OK", eTag: fr.config.httpETag, body: fr.config.configJson } as FetchResponse;
       });
 
     const options = createManualPollOptions(
@@ -850,7 +850,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 502, reasonPhrase: "Bad Gateway" });
+      .returnsAsync({ statusCode: 502, reasonPhrase: "Bad Gateway" } as FetchResponse);
 
     const cache = new InMemoryConfigCache();
 
@@ -880,7 +880,7 @@ describe("ConfigServiceBaseTests", () => {
 
     const fetcherMock = new Mock<IConfigFetcher>()
       .setup(m => m.fetchAsync(It.IsAny<FetchRequest>()))
-      .returnsAsync({ statusCode: 502, reasonPhrase: "Bad Gateway" });
+      .returnsAsync({ statusCode: 502, reasonPhrase: "Bad Gateway" } as FetchResponse);
 
     const cache = new InMemoryConfigCache();
 
@@ -909,7 +909,7 @@ describe("ConfigServiceBaseTests", () => {
     // Arrange
 
     const fakeFetcher = new FakeConfigFetcherBase(null, 1000,
-      () => ({ statusCode: 200, reasonPhrase: "OK", eTag: '"ETAG2"', body: '{ "p": { "s": "0" } }' }));
+      () => ({ statusCode: 200, reasonPhrase: "OK", eTag: '"ETAG2"', body: '{ "p": { "s": "0" } }' } as FetchResponse));
 
     const lastConfig = createProjectConfig('"ETAG"', "{}");
 

--- a/test/ConfigServiceBaseTests.ts
+++ b/test/ConfigServiceBaseTests.ts
@@ -483,6 +483,8 @@ describe("ConfigServiceBaseTests", () => {
 
     fetcherMock.verify(v => v.fetchAsync(It.Is<FetchRequest>(request => request.lastETag === "oldConfig")), Times.Once());
     cacheMock.verify(v => v.set(It.IsAny<string>(), It.Is<ProjectConfig>(c => c.httpETag === fr.config.httpETag && c.configJson === newConfig.configJson)), Times.Once());
+
+    service.dispose();
   });
 
   it("LazyLoadConfigService - ProjectConfig is cached - should not invoke fetch", async () => {
@@ -516,6 +518,8 @@ describe("ConfigServiceBaseTests", () => {
     assert.equal(actualConfig.configJson, config.configJson);
 
     fetcherMock.verify(v => v.fetchAsync(It.IsAny<FetchRequest>()), Times.Never());
+
+    service.dispose();
   });
 
   it("LazyLoadConfigService - refreshConfigAsync - should invoke fetch and cache.set operation", async () => {
@@ -556,6 +560,8 @@ describe("ConfigServiceBaseTests", () => {
 
     fetcherMock.verify(v => v.fetchAsync(It.IsAny<FetchRequest>()), Times.Once());
     cacheMock.verify(v => v.set(It.IsAny<string>(), It.IsAny<ProjectConfig>()), Times.Once());
+
+    service.dispose();
   });
 
   it("LazyLoadConfigService - refreshConfigAsync - should invoke fetch and cache.set operation - async cache supported", async () => {
@@ -596,6 +602,8 @@ describe("ConfigServiceBaseTests", () => {
 
     fetcherMock.verify(v => v.fetchAsync(It.IsAny<FetchRequest>()), Times.Once());
     cacheMock.verify(v => v.set(It.IsAny<string>(), It.IsAny<ProjectConfig>()), Times.Once());
+
+    service.dispose();
   });
 
   it("AutoPollConfigService - getConfigAsync() should return cached config when cached config is not expired", async () => {
@@ -724,6 +732,8 @@ describe("ConfigServiceBaseTests", () => {
     assert.strictEqual(cachedPc, actualPc);
 
     fetcherMock.verify(v => v.fetchAsync(It.IsAny<FetchRequest>()), Times.Never());
+
+    service.dispose();
   });
 
   it("LazyLoadConfigService - getConfigAsync() should fetch when cached config is expired", async () => {
@@ -767,6 +777,8 @@ describe("ConfigServiceBaseTests", () => {
     assert.equal(fr.config.configJson, actualPc.configJson);
 
     fetcherMock.verify(v => v.fetchAsync(It.IsAny<FetchRequest>()), Times.Once());
+
+    service.dispose();
   });
 
   it("fetchAsync() should not initiate a request when there is a pending one", async () => {
@@ -803,6 +815,8 @@ describe("ConfigServiceBaseTests", () => {
     assert.equal(pc.configJson, config1.configJson);
 
     fetcherMock.verify(v => v.fetchAsync(It.IsAny<FetchRequest>()), Times.Once());
+
+    service.dispose();
   });
 
   it("fetchAsync() should initiate a request when there is not a pending one", async () => {
@@ -842,6 +856,8 @@ describe("ConfigServiceBaseTests", () => {
     assert.equal(pc.configJson, config2.configJson);
 
     fetcherMock.verify(v => v.fetchAsync(It.IsAny<FetchRequest>()), Times.Exactly(2));
+
+    service.dispose();
   });
 
   it("refreshConfigAsync() should return null config when cache is empty and fetch fails.", async () => {
@@ -870,6 +886,8 @@ describe("ConfigServiceBaseTests", () => {
 
     assert.isTrue(projectConfig.isEmpty);
     assert.isTrue((cache.get(options.getCacheKey())).isEmpty);
+
+    service.dispose();
   });
 
   it("refreshConfigAsync() should return latest config when cache is empty and fetch fails.", async () => {
@@ -902,6 +920,8 @@ describe("ConfigServiceBaseTests", () => {
 
     assert.strictEqual(projectConfig, cachedPc);
     assert.strictEqual(cache.get(options.getCacheKey()), cachedPc);
+
+    service.dispose();
   });
 
   it("refreshConfigAsync() - only one config refresh should be in progress at a time - success", async () => {

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -276,7 +276,7 @@ export class FakeConfigFetcher implements IConfigFetcher {
       assert.fail("ConfigFetcher not prepared for " + url);
     }
     this.calls.push(url);
-    return Promise.resolve<FetchResponse>({ statusCode: 200, reasonPhrase: "OK", eTag: projectConfig.config.httpETag, body: projectConfig.config.configJson });
+    return Promise.resolve({ statusCode: 200, reasonPhrase: "OK", eTag: projectConfig.config.httpETag, body: projectConfig.config.configJson } as FetchResponse);
   }
 }
 

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -331,7 +331,7 @@ export class FakeConfigServiceBase extends ConfigServiceBase<FakeOptions> {
   }
 
   private getUrl(baseUrl: string) {
-    return baseUrl + "/configuration-files/API_KEY/config_v6.json?sdk=" + this.options.clientVersion;
+    return baseUrl + "/configuration-files/API_KEY/config_v6.json";
   }
 
   getCacheState(cachedConfig: ProjectConfig): ClientCacheState {

--- a/test/IntegrationTests.ts
+++ b/test/IntegrationTests.ts
@@ -1,7 +1,8 @@
 import { assert, expect } from "chai";
 import { FakeLogger } from "./helpers/fakes";
 import { platform } from "./helpers/platform";
-import { EvaluationDetails, FormattableLogMessage, IConfigCatClient, IOptions, LogLevel, OverrideBehaviour, PollingMode, SettingKeyValue, User } from "#lib";
+import { EvaluationDetails, FetchError, FetchResponse, FormattableLogMessage, IConfigCatClient, IConfigCatConfigFetcher, IOptions, LogLevel, OverrideBehaviour, PollingMode, SettingKeyValue, User } from "#lib";
+import { FetchErrorCtorInternal } from "#lib/ConfigFetcher";
 import { createConsoleLogger, createFlagOverridesFromMap } from "#lib/index.pubternals";
 
 const sdkKey = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";
@@ -297,33 +298,60 @@ describe("Integration tests - Other cases", () => {
     } finally { clientOverride.dispose(); }
   });
 
-  it("Should include ray ID in log messages when http response is not successful", async function() {
-    const fakeLogger = new FakeLogger();
+  for (const testCase of <("404" | "408" | "timeout" | "error")[]>["404", "408", "timeout", "error"]) {
+    it(`Should include ray ID in log messages when http response is not successful - testCase: ${testCase}`, async function() {
+      const fakeLogger = new FakeLogger();
 
-    const client: IConfigCatClient = platform().getClient("configcat-sdk-1/~~~~~~~~~~~~~~~~~~~~~~/~~~~~~~~~~~~~~~~~~~~~~", PollingMode.ManualPoll, { logger: fakeLogger });
+      const rayId = "CF-RAY-123";
 
-    try {
-      await client.forceRefreshAsync();
+      const [fetchCallback, expectedEventId] =
+        testCase === "404" ? [() => new FetchResponse(404, "Not Found", [["CF-RAY", rayId]]), 1100]
+        : testCase === "408" ? [() => new FetchResponse(408, "Request Timeout", [["CF-RAY", rayId]]), 1101]
+        : testCase === "timeout" ? [() => { throw new (FetchError as FetchErrorCtorInternal)("timeout", 0, rayId); }, 1102]
+        : [() => { throw new (FetchError as FetchErrorCtorInternal)("failure", Error("Network error"), rayId); }, 1103];
 
-      const errors = fakeLogger.events.filter(([, eventId]) => eventId === 1100);
-      assert.strictEqual(errors.length, 1);
+      const fakeConfigFetcher = new class implements IConfigCatConfigFetcher {
+        constructor(private readonly fetchCallback: () => FetchResponse) {}
 
-      const [[, , error]] = errors;
-      assert.instanceOf(error, FormattableLogMessage);
+        fetchAsync(): Promise<FetchResponse> {
+          try {
+            return Promise.resolve(this.fetchCallback());
+          } catch (err) { return Promise.reject(err as Error); }
+        }
+      }(fetchCallback);
 
-      assert.strictEqual(error.argNames.length, 2);
-      assert.strictEqual(error.argNames[0], "SDK_KEY");
-      assert.strictEqual(error.argNames[1], "RAY_ID");
+      const client: IConfigCatClient = platform().getClient(
+        "configcat-sdk-1/~~~~~~~~~~~~~~~~~~~~~~/~~~~~~~~~~~~~~~~~~~~~~",
+        PollingMode.ManualPoll,
+        { logger: fakeLogger, configFetcher: fakeConfigFetcher }
+      );
 
-      assert.strictEqual(error.argValues.length, 2);
-      const [actualSdkKey, actualRayId] = error.argValues;
-      assert.equal(actualSdkKey, "***************/**********************/****************~~~~~~");
-      assert.isString(actualRayId);
+      try {
+        await client.forceRefreshAsync();
 
-      expect(error.toString()).to.contain(actualRayId);
-    } finally {
-      client.dispose();
-    }
-  });
+        const events = fakeLogger.events.filter(([, eventId]) => eventId === expectedEventId);
+        assert.strictEqual(events.length, 1);
+
+        const [[, , message]] = events;
+
+        if (testCase === "404") {
+          assert.instanceOf(message, FormattableLogMessage);
+
+          assert.strictEqual(message.argNames.length, 2);
+          assert.strictEqual(message.argNames[0], "SDK_KEY");
+          assert.strictEqual(message.argNames[1], "RAY_ID");
+
+          assert.strictEqual(message.argValues.length, 2);
+          const [actualSdkKey, actualRayId] = message.argValues;
+          assert.equal(actualSdkKey, "***************/**********************/****************~~~~~~");
+          assert.equal(actualRayId, rayId);
+        }
+
+        expect(message.toString()).to.contain(rayId);
+      } finally {
+        client.dispose();
+      }
+    });
+  }
 
 });

--- a/test/IntegrationTests.ts
+++ b/test/IntegrationTests.ts
@@ -2,8 +2,7 @@ import { assert, expect } from "chai";
 import { FakeLogger } from "./helpers/fakes";
 import { platform } from "./helpers/platform";
 import { EvaluationDetails, FormattableLogMessage, IConfigCatClient, IOptions, LogLevel, OverrideBehaviour, PollingMode, SettingKeyValue, User } from "#lib";
-import { ConfigCatClient } from "#lib/ConfigCatClient";
-import { createConsoleLogger, createFlagOverridesFromMap, OptionsBase } from "#lib/index.pubternals";
+import { createConsoleLogger, createFlagOverridesFromMap } from "#lib/index.pubternals";
 
 const sdkKey = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";
 
@@ -304,12 +303,6 @@ describe("Integration tests - Other cases", () => {
     const client: IConfigCatClient = platform().getClient("configcat-sdk-1/~~~~~~~~~~~~~~~~~~~~~~/~~~~~~~~~~~~~~~~~~~~~~", PollingMode.ManualPoll, { logger: fakeLogger });
 
     try {
-      // TODO: Remove this as soon as we update the CDN CORS settings (see also https://trello.com/c/RSGwVoqC)
-      const clientVersion: string = (((client as ConfigCatClient)["options"]) as OptionsBase)["clientVersion"];
-      if (clientVersion.includes("ConfigCat-UnifiedJS-Browser") || clientVersion.includes("ConfigCat-UnifiedJS-ChromiumExtension")) {
-        this.skip();
-      }
-
       await client.forceRefreshAsync();
 
       const errors = fakeLogger.events.filter(([, eventId]) => eventId === 1100);

--- a/test/IntegrationTests.ts
+++ b/test/IntegrationTests.ts
@@ -206,10 +206,12 @@ describe("Integration tests - Wrong SDK key", () => {
     const client: IConfigCatClient = platform().getClient("WRONG_SDK_KEY-56789012/1234567890123456789012", PollingMode.AutoPoll,
       { requestTimeoutMs: 500, maxInitWaitTimeSeconds: 1 });
 
-    const actual: string = await client.getValueAsync("stringDefaultCat", defaultValue);
-    assert.strictEqual(actual, defaultValue);
-
-    client.dispose();
+    try {
+      const actual: string = await client.getValueAsync("stringDefaultCat", defaultValue);
+      assert.strictEqual(actual, defaultValue);
+    } finally {
+      client.dispose();
+    }
   });
 
   it("Manual poll with wrong SDK Key - getValueAsync() should return default value", async () => {
@@ -217,13 +219,15 @@ describe("Integration tests - Wrong SDK key", () => {
     const defaultValue = "NOT_CAT";
     const client: IConfigCatClient = platform().getClient("WRONG_SDK_KEY-56789012/1234567890123456789012", PollingMode.ManualPoll, { requestTimeoutMs: 500 });
 
-    const actual: string = await client.getValueAsync("stringDefaultCat", defaultValue);
-    assert.strictEqual(actual, defaultValue);
-    await client.forceRefreshAsync();
-    const actual2: string = await client.getValueAsync("stringDefaultCat", defaultValue);
-    assert.strictEqual(actual2, defaultValue);
-
-    client.dispose();
+    try {
+      const actual: string = await client.getValueAsync("stringDefaultCat", defaultValue);
+      assert.strictEqual(actual, defaultValue);
+      await client.forceRefreshAsync();
+      const actual2: string = await client.getValueAsync("stringDefaultCat", defaultValue);
+      assert.strictEqual(actual2, defaultValue);
+    } finally {
+      client.dispose();
+    }
   });
 
   it("Lazy load with wrong SDK Key - getValueAsync() should return default value", async () => {
@@ -231,20 +235,24 @@ describe("Integration tests - Wrong SDK key", () => {
     const defaultValue = "NOT_CAT";
     const client: IConfigCatClient = platform().getClient("WRONG_SDK_KEY-56789012/1234567890123456789012", PollingMode.LazyLoad, { requestTimeoutMs: 500 });
 
-    const actual: string = await client.getValueAsync("stringDefaultCat", defaultValue);
-    assert.strictEqual(actual, defaultValue);
-
-    client.dispose();
+    try {
+      const actual: string = await client.getValueAsync("stringDefaultCat", defaultValue);
+      assert.strictEqual(actual, defaultValue);
+    } finally {
+      client.dispose();
+    }
   });
 
   it("getAllKeysAsync() should not crash with wrong SDK Key", async () => {
 
     const client: IConfigCatClient = platform().getClient("WRONG_SDK_KEY-56789012/1234567890123456789012", PollingMode.ManualPoll, { requestTimeoutMs: 500 });
 
-    const keys: string[] = await client.getAllKeysAsync();
-    assert.equal(keys.length, 0);
-
-    client.dispose();
+    try {
+      const keys: string[] = await client.getAllKeysAsync();
+      assert.equal(keys.length, 0);
+    } finally {
+      client.dispose();
+    }
   });
 });
 
@@ -295,32 +303,34 @@ describe("Integration tests - Other cases", () => {
 
     const client: IConfigCatClient = platform().getClient("configcat-sdk-1/~~~~~~~~~~~~~~~~~~~~~~/~~~~~~~~~~~~~~~~~~~~~~", PollingMode.ManualPoll, { logger: fakeLogger });
 
-    // TODO: Remove this as soon as we update the CDN CORS settings (see also https://trello.com/c/RSGwVoqC)
-    const clientVersion: string = (((client as ConfigCatClient)["options"]) as OptionsBase)["clientVersion"];
-    if (clientVersion.includes("ConfigCat-UnifiedJS-Browser") || clientVersion.includes("ConfigCat-UnifiedJS-ChromiumExtension")) {
-      this.skip();
+    try {
+      // TODO: Remove this as soon as we update the CDN CORS settings (see also https://trello.com/c/RSGwVoqC)
+      const clientVersion: string = (((client as ConfigCatClient)["options"]) as OptionsBase)["clientVersion"];
+      if (clientVersion.includes("ConfigCat-UnifiedJS-Browser") || clientVersion.includes("ConfigCat-UnifiedJS-ChromiumExtension")) {
+        this.skip();
+      }
+
+      await client.forceRefreshAsync();
+
+      const errors = fakeLogger.events.filter(([, eventId]) => eventId === 1100);
+      assert.strictEqual(errors.length, 1);
+
+      const [[, , error]] = errors;
+      assert.instanceOf(error, FormattableLogMessage);
+
+      assert.strictEqual(error.argNames.length, 2);
+      assert.strictEqual(error.argNames[0], "SDK_KEY");
+      assert.strictEqual(error.argNames[1], "RAY_ID");
+
+      assert.strictEqual(error.argValues.length, 2);
+      const [actualSdkKey, actualRayId] = error.argValues;
+      assert.equal(actualSdkKey, "***************/**********************/****************~~~~~~");
+      assert.isString(actualRayId);
+
+      expect(error.toString()).to.contain(actualRayId);
+    } finally {
+      client.dispose();
     }
-
-    await client.forceRefreshAsync();
-
-    const errors = fakeLogger.events.filter(([, eventId]) => eventId === 1100);
-    assert.strictEqual(errors.length, 1);
-
-    const [[, , error]] = errors;
-    assert.instanceOf(error, FormattableLogMessage);
-
-    assert.strictEqual(error.argNames.length, 2);
-    assert.strictEqual(error.argNames[0], "SDK_KEY");
-    assert.strictEqual(error.argNames[1], "RAY_ID");
-
-    assert.strictEqual(error.argValues.length, 2);
-    const [actualSdkKey, actualRayId] = error.argValues;
-    assert.equal(actualSdkKey, "***************/**********************/****************~~~~~~");
-    assert.isString(actualRayId);
-
-    expect(error.toString()).to.contain(actualRayId);
-
-    client.dispose();
   });
 
 });

--- a/test/browser/HttpTests.ts
+++ b/test/browser/HttpTests.ts
@@ -10,7 +10,7 @@ describe("HTTP tests", () => {
   const baseUrl = "https://cdn-global.test.com";
 
   it("HTTP timeout", async () => {
-    const requestTimeoutMs = 1500;
+    const requestTimeoutMs = 750;
 
     const server = mockxmlhttprequest.newServer({
       get: [url => url.startsWith(baseUrl), request => setTimeout(() => request.setRequestTimeout(), requestTimeoutMs)],
@@ -29,6 +29,7 @@ describe("HTTP tests", () => {
       const startTime = getMonotonicTimeMs();
       const refreshResult = await client.forceRefreshAsync();
       const duration = getMonotonicTimeMs() - startTime;
+      // NOTE: Elapsed time is expected to be twice as `requestTimeoutMs` due to retry.
       assert.isTrue(duration > 1000 && duration < 2000);
 
       const defaultValue = "NOT_CAT";

--- a/test/browser/HttpTests.ts
+++ b/test/browser/HttpTests.ts
@@ -3,7 +3,7 @@ import * as mockxmlhttprequest from "mock-xmlhttprequest";
 import { FakeLogger } from "../helpers/fakes";
 import { platform } from ".";
 import { LogLevel, RefreshErrorCode } from "#lib";
-import { getMonotonicTimeMs } from "#lib/Utils";
+import { delay, errorToString, getMonotonicTimeMs } from "#lib/Utils";
 
 describe("HTTP tests", () => {
   const sdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/AG6C1ngVb0CvM07un6JisQ";
@@ -12,14 +12,19 @@ describe("HTTP tests", () => {
   it("HTTP timeout", async () => {
     const requestTimeoutMs = 750;
 
+    let requestCount = 0;
+
     const server = mockxmlhttprequest.newServer({
-      get: [url => url.startsWith(baseUrl), request => setTimeout(() => request.setRequestTimeout(), requestTimeoutMs)],
+      get: [
+        url => url.startsWith(baseUrl),
+        request => (++requestCount, setTimeout(() => request.setRequestTimeout(), requestTimeoutMs)),
+      ],
     });
 
     try {
       server.install(window);
 
-      const logger = new FakeLogger();
+      const logger = new FakeLogger(LogLevel.Debug);
 
       const client = platform.createClientWithManualPoll(sdkKey, {
         requestTimeoutMs,
@@ -38,6 +43,8 @@ describe("HTTP tests", () => {
       assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.HttpRequestTimeout);
       assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Request timed out while trying to fetch config JSON.")));
 
+      assert.strictEqual(requestCount, 2);
+
       client.dispose();
     } finally {
       server.remove();
@@ -45,14 +52,19 @@ describe("HTTP tests", () => {
   });
 
   it("404 Not found", async () => {
+    let requestCount = 0;
+
     const server = mockxmlhttprequest.newServer({
-      get: [url => url.startsWith(baseUrl), { status: 404, statusText: "Not Found" }],
+      get: [
+        url => url.startsWith(baseUrl),
+        request => (++requestCount, request.setResponseHeaders(404, null, "Not Found"), request.setResponseBody()),
+      ],
     });
 
     try {
       server.install(window);
 
-      const logger = new FakeLogger();
+      const logger = new FakeLogger(LogLevel.Debug);
 
       const client = platform.createClientWithManualPoll(sdkKey, {
         requestTimeoutMs: 1000,
@@ -68,6 +80,8 @@ describe("HTTP tests", () => {
       assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.InvalidSdkKey);
       assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Your SDK Key seems to be wrong:")));
 
+      assert.strictEqual(requestCount, 1);
+
       client.dispose();
     } finally {
       server.remove();
@@ -75,14 +89,19 @@ describe("HTTP tests", () => {
   });
 
   it("Unexpected status code", async () => {
+    let requestCount = 0;
+
     const server = mockxmlhttprequest.newServer({
-      get: [url => url.startsWith(baseUrl), { status: 502, statusText: "Bad Gateway" }],
+      get: [
+        url => url.startsWith(baseUrl),
+        request => (++requestCount, request.setResponseHeaders(502, null, "Bad Gateway"), request.setResponseBody()),
+      ],
     });
 
     try {
       server.install(window);
 
-      const logger = new FakeLogger();
+      const logger = new FakeLogger(LogLevel.Debug);
 
       const client = platform.createClientWithManualPoll(sdkKey, {
         requestTimeoutMs: 1000,
@@ -98,6 +117,8 @@ describe("HTTP tests", () => {
       assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.UnexpectedHttpResponse);
       assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Unexpected HTTP response was received while trying to fetch config JSON:")));
 
+      assert.strictEqual(requestCount, 2);
+
       client.dispose();
     } finally {
       server.remove();
@@ -105,14 +126,19 @@ describe("HTTP tests", () => {
   });
 
   it("Unexpected error", async () => {
+    let requestCount = 0;
+
     const server = mockxmlhttprequest.newServer({
-      get: [url => url.startsWith(baseUrl), "error"],
+      get: [
+        url => url.startsWith(baseUrl),
+        request => (++requestCount, request.setNetworkError()),
+      ],
     });
 
     try {
       server.install(window);
 
-      const logger = new FakeLogger();
+      const logger = new FakeLogger(LogLevel.Debug);
 
       const client = platform.createClientWithManualPoll(sdkKey, {
         requestTimeoutMs: 1000,
@@ -128,7 +154,53 @@ describe("HTTP tests", () => {
       assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.HttpRequestFailure);
       assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Unexpected error occurred while trying to fetch config JSON.")));
 
+      assert.strictEqual(requestCount, 2);
+
       client.dispose();
+    } finally {
+      server.remove();
+    }
+  });
+
+  it("Abort on dispose", async () => {
+    const delayMs = 250;
+
+    let requestCount = 0;
+
+    const server = mockxmlhttprequest.newServer({
+      get: [
+        url => url.startsWith(baseUrl),
+        request => {
+          ++requestCount;
+          delay(delayMs).then(() => {
+            request.setResponseHeaders(502, null, "Bad Gateway");
+            request.setResponseBody();
+          });
+        },
+      ],
+    });
+
+    try {
+      server.install(window);
+
+      const logger = new FakeLogger(LogLevel.Debug);
+
+      const client = platform.createClientWithManualPoll(sdkKey, {
+        requestTimeoutMs: 1000,
+        baseUrl,
+        logger,
+      });
+
+      const forceRefreshPromise = client.forceRefreshAsync();
+      await delay(delayMs / 5);
+      client.dispose();
+      const refreshResult = await forceRefreshPromise;
+
+      assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.UnexpectedError);
+      assert.include(refreshResult.errorMessage?.toString(), "Request was aborted.");
+      assert.isDefined(logger.events.find(([level, eventId, , err]) => level === LogLevel.Error && eventId === 1003 && errorToString(err).includes("Request was aborted.")));
+
+      assert.strictEqual(requestCount, 1);
     } finally {
       server.remove();
     }

--- a/test/browser/IndexTests.ts
+++ b/test/browser/IndexTests.ts
@@ -8,9 +8,11 @@ describe("ConfigCatClient index (main)", () => {
 
       const client: IConfigCatClient = configcatClient.getClient("SDKKEY-890123456789012/1234567890123456789012", pollingMode);
 
-      assert.isDefined(client);
-
-      client.dispose();
+      try {
+        assert.isDefined(client);
+      } finally {
+        client.dispose();
+      }
     });
   }
 

--- a/test/browser/XmlHttpRequestConfigFetcherTests.ts
+++ b/test/browser/XmlHttpRequestConfigFetcherTests.ts
@@ -1,0 +1,107 @@
+import { assert } from "chai";
+import { platform } from ".";
+import { FetchRequest, FetchResponse } from "#lib";
+import { XmlHttpRequestConfigFetcher } from "#lib/browser";
+import { CONFIGCAT_USER_AGENT_HEADER_NAME, ETAG_QUERYPARAM_NAME, getRequestHeaders, SDK_QUERYPARAM_NAME, USER_AGENT_HEADER_NAME } from "#lib/ConfigFetcher";
+
+const testSdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g";
+const testETag = "W/\"123\"";
+
+describe("XmlHttpRequestConfigFetcher tests", () => {
+  for (const [eTag, useCustomUrl, addCustomHeaders] of <[string | undefined, boolean, boolean][]>[
+    [void 0, false, false],
+    [void 0, false, true],
+    [void 0, true, false],
+    [void 0, true, true],
+    [testETag, false, false],
+    [testETag, false, true],
+    [testETag, true, false],
+    [testETag, true, true],
+  ]) {
+    it(`Should not send user agent headers - eTag: ${eTag} | useCustomUrl: ${useCustomUrl} | addCustomHeaders: ${addCustomHeaders}`, async () => {
+      // Arrange
+
+      const timeoutMs = 15_000;
+
+      const capturedRequests: [url: string, headers: ReadonlyArray<readonly [name: string, value: string]> | undefined][] = [];
+
+      const extraHeaders: [string, string][] | undefined = addCustomHeaders
+        ? [
+          ["X-Custom", "1"],
+          [CONFIGCAT_USER_AGENT_HEADER_NAME, "x"],
+        ]
+        : void 0;
+
+      const configFetcher = new XmlHttpRequestConfigFetcher();
+
+      configFetcher["fetchCoreAsync"] = function(...args: unknown[]) {
+        const url = args[0] as string;
+        const headers = args[1] as ReadonlyArray<readonly [name: string, value: string]> | undefined;
+        capturedRequests.push([url, headers ? extraHeaders : void 0]);
+        return new FetchResponse(200, "OK", [], "{}");
+      };
+
+      const options = platform.createManualPollOptions(testSdkKey);
+
+      const requestUrl = useCustomUrl
+        ? "http://example.com/configcat?x#y"
+        : options.getUrl();
+      const requestHeaders = getRequestHeaders(options.clientVersion);
+      const fetchRequest = new FetchRequest(requestUrl, eTag, requestHeaders, timeoutMs);
+
+      // Act
+
+      await configFetcher.fetchAsync(fetchRequest);
+
+      configFetcher.dispose();
+
+      // Assert
+
+      assert.equal(capturedRequests.length, 1);
+
+      const [[actualRequestUrl, actualRequestHeaders]] = capturedRequests;
+
+      const parsedExpectedUrl = new URL(requestUrl);
+      const parsedActualUrl = new URL(actualRequestUrl);
+      assert.equal(parsedActualUrl.origin, parsedExpectedUrl.origin);
+      assert.equal(parsedActualUrl.pathname, parsedExpectedUrl.pathname);
+
+      const parsedActualQuery = parsedActualUrl.searchParams;
+      const [, expectedUserAgentHeaderValue] = fetchRequest.headers.find(([name]) => name === USER_AGENT_HEADER_NAME)!;
+      assert.deepEqual(parsedActualQuery.getAll(SDK_QUERYPARAM_NAME), [expectedUserAgentHeaderValue]);
+      assert.deepEqual(parsedActualQuery.getAll(ETAG_QUERYPARAM_NAME), eTag ? [eTag] : useCustomUrl ? [""] : []);
+
+      const eTagHeaderValues: string[] = [];
+      if (actualRequestHeaders) {
+        for (const [key, value] of actualRequestHeaders) {
+          if (key.toLowerCase() === "if-none-match") {
+            eTagHeaderValues.push(value);
+          }
+        }
+      }
+
+      assert.equal(eTagHeaderValues.length, 0);
+
+      const expectedHeaders: Record<string, string[]> = {};
+      for (const [key, value] of useCustomUrl && addCustomHeaders ? extraHeaders! : []) {
+        const normalizedKey = key.toLowerCase();
+        let currentValues = expectedHeaders[normalizedKey];
+        if (!currentValues) currentValues = expectedHeaders[normalizedKey] = [];
+        currentValues.push(value);
+      }
+
+      const actualHeaders: Record<string, string[]> = {};
+      if (actualRequestHeaders) {
+        for (const [key, value] of actualRequestHeaders) {
+          const normalizedKey = key.toLowerCase();
+          if (eTag && normalizedKey === "if-none-match") continue;
+          let currentValues = actualHeaders[normalizedKey];
+          if (!currentValues) currentValues = actualHeaders[normalizedKey] = [];
+          currentValues.push(value);
+        }
+      }
+
+      assert.deepEqual(actualHeaders, expectedHeaders);
+    });
+  }
+});

--- a/test/bun/ClientTests.ts
+++ b/test/bun/ClientTests.ts
@@ -9,9 +9,11 @@ describe("ConfigCatClient tests", () => {
 
       const client: IConfigCatClient = configcatClient.getClient("SDKKEY-890123456789012/1234567890123456789012", pollingMode);
 
-      assert.isDefined(client);
-
-      client.dispose();
+      try {
+        assert.isDefined(client);
+      } finally {
+        client.dispose();
+      }
     });
   }
 

--- a/test/chromium-extension/ClientSideFetchApiConfigFetcherTests.ts
+++ b/test/chromium-extension/ClientSideFetchApiConfigFetcherTests.ts
@@ -1,0 +1,113 @@
+import { assert } from "chai";
+import { platform } from ".";
+import { FetchRequest } from "#lib";
+import { ClientSideFetchApiConfigFetcher } from "#lib/chromium-extension";
+import { CONFIGCAT_USER_AGENT_HEADER_NAME, ETAG_QUERYPARAM_NAME, getRequestHeaders, SDK_QUERYPARAM_NAME, USER_AGENT_HEADER_NAME } from "#lib/ConfigFetcher";
+
+const testSdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g";
+const testETag = "W/\"123\"";
+
+describe("ClientSideFetchApiConfigFetcher tests", () => {
+  for (const [eTag, useCustomUrl, addCustomHeaders] of <[string | undefined, boolean, boolean][]>[
+    [void 0, false, false],
+    [void 0, false, true],
+    [void 0, true, false],
+    [void 0, true, true],
+    [testETag, false, false],
+    [testETag, false, true],
+    [testETag, true, false],
+    [testETag, true, true],
+  ]) {
+    it(`Should not send user agent headers - eTag: ${eTag} | useCustomUrl: ${useCustomUrl} | addCustomHeaders: ${addCustomHeaders}`, async () => {
+      // Arrange
+
+      const timeoutMs = 15_000;
+
+      const capturedRequests: [url: string, headers: [string, string][] | undefined][] = [];
+
+      const extraHeaders: [string, string][] | undefined = addCustomHeaders
+        ? [
+          ["X-Custom", "1"],
+          [CONFIGCAT_USER_AGENT_HEADER_NAME, "x"],
+        ]
+        : void 0;
+
+      const configFetcher = new class extends ClientSideFetchApiConfigFetcher {
+        protected override setRequestHeaders(requestInit: { headers?: [string, string][] }, headers: ReadonlyArray<readonly [string, string]>): void {
+          for (const [name, value] of extraHeaders ?? []) {
+            (requestInit.headers ??= []).push([name, value]);
+          }
+        }
+      }();
+
+      configFetcher["fetchCoreAsync"] = function(...args: unknown[]) {
+        const url = args[0] as string;
+        const requestInit = args[1] as RequestInit & { headers?: [string, string][] };
+        capturedRequests.push([url, requestInit.headers]);
+        return { status: 200, statusText: "OK", headers: new Headers([]), text: () => Promise.resolve("{}") } as Response;
+      };
+
+      const options = platform.createManualPollOptions(testSdkKey);
+
+      const requestUrl = useCustomUrl
+        ? "http://example.com/configcat?x#y"
+        : options.getUrl();
+      const requestHeaders = getRequestHeaders(options.clientVersion);
+      const fetchRequest = new FetchRequest(requestUrl, eTag, requestHeaders, timeoutMs);
+
+      // Act
+
+      await configFetcher.fetchAsync(fetchRequest);
+
+      configFetcher.dispose();
+
+      // Assert
+
+      assert.equal(capturedRequests.length, 1);
+
+      const [[actualRequestUrl, actualRequestHeaders]] = capturedRequests;
+
+      const parsedExpectedUrl = new URL(requestUrl);
+      const parsedActualUrl = new URL(actualRequestUrl);
+      assert.equal(parsedActualUrl.origin, parsedExpectedUrl.origin);
+      assert.equal(parsedActualUrl.pathname, parsedExpectedUrl.pathname);
+
+      const parsedActualQuery = parsedActualUrl.searchParams;
+      const [, expectedUserAgentHeaderValue] = fetchRequest.headers.find(([name]) => name === USER_AGENT_HEADER_NAME)!;
+      assert.deepEqual(parsedActualQuery.getAll(SDK_QUERYPARAM_NAME), [expectedUserAgentHeaderValue]);
+      assert.deepEqual(parsedActualQuery.getAll(ETAG_QUERYPARAM_NAME), eTag ? [eTag] : useCustomUrl ? [""] : []);
+
+      const eTagHeaderValues: string[] = [];
+      if (actualRequestHeaders) {
+        for (const [key, value] of actualRequestHeaders) {
+          if (key.toLowerCase() === "if-none-match") {
+            eTagHeaderValues.push(value);
+          }
+        }
+      }
+
+      assert.equal(eTagHeaderValues.length, 0);
+
+      const expectedHeaders: Record<string, string[]> = {};
+      for (const [key, value] of useCustomUrl && addCustomHeaders ? extraHeaders! : []) {
+        const normalizedKey = key.toLowerCase();
+        let currentValues = expectedHeaders[normalizedKey];
+        if (!currentValues) currentValues = expectedHeaders[normalizedKey] = [];
+        currentValues.push(value);
+      }
+
+      const actualHeaders: Record<string, string[]> = {};
+      if (actualRequestHeaders) {
+        for (const [key, value] of actualRequestHeaders) {
+          const normalizedKey = key.toLowerCase();
+          if (eTag && normalizedKey === "if-none-match") continue;
+          let currentValues = actualHeaders[normalizedKey];
+          if (!currentValues) currentValues = actualHeaders[normalizedKey] = [];
+          currentValues.push(value);
+        }
+      }
+
+      assert.deepEqual(actualHeaders, expectedHeaders);
+    });
+  }
+});

--- a/test/chromium-extension/HttpTests.ts
+++ b/test/chromium-extension/HttpTests.ts
@@ -11,10 +11,10 @@ describe("HTTP tests", () => {
 
   if (typeof AbortController !== "undefined") {
     it("HTTP timeout", async () => {
-      const requestTimeoutMs = 1500;
+      const requestTimeoutMs = 750;
 
       fetchMock.get(url => url.startsWith(baseUrl),
-        new Promise(resolve => setTimeout(() => resolve({ throws: new Error("Test failed.") }), requestTimeoutMs * 2)));
+        new Promise(resolve => setTimeout(() => resolve({ throws: new Error("Test failed.") }), requestTimeoutMs * 4)));
 
       try {
         const logger = new FakeLogger();
@@ -27,6 +27,7 @@ describe("HTTP tests", () => {
         const startTime = getMonotonicTimeMs();
         const refreshResult = await client.forceRefreshAsync();
         const duration = getMonotonicTimeMs() - startTime;
+        // NOTE: Elapsed time is expected to be twice as `requestTimeoutMs` due to retry.
         assert.isTrue(duration > 1000 && duration < 2000);
 
         const defaultValue = "NOT_CAT";

--- a/test/chromium-extension/HttpTests.ts
+++ b/test/chromium-extension/HttpTests.ts
@@ -3,7 +3,7 @@ import fetchMock from "fetch-mock";
 import { FakeLogger } from "../helpers/fakes";
 import { platform } from ".";
 import { LogLevel, RefreshErrorCode } from "#lib";
-import { getMonotonicTimeMs } from "#lib/Utils";
+import { delay, errorToString, getMonotonicTimeMs } from "#lib/Utils";
 
 describe("HTTP tests", () => {
   const sdkKey = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";
@@ -13,11 +13,15 @@ describe("HTTP tests", () => {
     it("HTTP timeout", async () => {
       const requestTimeoutMs = 750;
 
-      fetchMock.get(url => url.startsWith(baseUrl),
-        new Promise(resolve => setTimeout(() => resolve({ throws: new Error("Test failed.") }), requestTimeoutMs * 4)));
+      let requestCount = 0;
+
+      fetchMock.get(
+        url => url.startsWith(baseUrl),
+        () => (++requestCount, new Promise(resolve => setTimeout(() => resolve({ throws: new Error("Test failed.") }), requestTimeoutMs * 4)))
+      );
 
       try {
-        const logger = new FakeLogger();
+        const logger = new FakeLogger(LogLevel.Debug);
 
         const client = platform.createClientWithManualPoll(sdkKey, {
           requestTimeoutMs,
@@ -36,6 +40,8 @@ describe("HTTP tests", () => {
         assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.HttpRequestTimeout);
         assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Request timed out while trying to fetch config JSON.")));
 
+        assert.strictEqual(requestCount, 2);
+
         client.dispose();
       } finally {
         fetchMock.reset();
@@ -44,10 +50,15 @@ describe("HTTP tests", () => {
   }
 
   it("404 Not found", async () => {
-    fetchMock.get(url => url.startsWith(baseUrl), 404);
+    let requestCount = 0;
+
+    fetchMock.get(
+      url => url.startsWith(baseUrl),
+      () => (++requestCount, 404)
+    );
 
     try {
-      const logger = new FakeLogger();
+      const logger = new FakeLogger(LogLevel.Debug);
 
       const client = platform.createClientWithManualPoll(sdkKey, {
         requestTimeoutMs: 1000,
@@ -63,6 +74,8 @@ describe("HTTP tests", () => {
       assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.InvalidSdkKey);
       assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Your SDK Key seems to be wrong:")));
 
+      assert.strictEqual(requestCount, 1);
+
       client.dispose();
     } finally {
       fetchMock.reset();
@@ -70,10 +83,15 @@ describe("HTTP tests", () => {
   });
 
   it("Unexpected status code", async () => {
-    fetchMock.get(url => url.startsWith(baseUrl), 502);
+    let requestCount = 0;
+
+    fetchMock.get(
+      url => url.startsWith(baseUrl),
+      () => (++requestCount, 502)
+    );
 
     try {
-      const logger = new FakeLogger();
+      const logger = new FakeLogger(LogLevel.Debug);
 
       const client = platform.createClientWithManualPoll(sdkKey, {
         requestTimeoutMs: 1000,
@@ -89,6 +107,8 @@ describe("HTTP tests", () => {
       assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.UnexpectedHttpResponse);
       assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Unexpected HTTP response was received while trying to fetch config JSON:")));
 
+      assert.strictEqual(requestCount, 2);
+
       client.dispose();
     } finally {
       fetchMock.reset();
@@ -96,11 +116,15 @@ describe("HTTP tests", () => {
   });
 
   it("Unexpected error", async () => {
-    fetchMock.get(url => url.startsWith(baseUrl),
-      { throws: new Error("Connection error.") });
+    let requestCount = 0;
+
+    fetchMock.get(
+      url => url.startsWith(baseUrl),
+      () => (++requestCount, { throws: new Error("Connection error.") })
+    );
 
     try {
-      const logger = new FakeLogger();
+      const logger = new FakeLogger(LogLevel.Debug);
 
       const client = platform.createClientWithManualPoll(sdkKey, {
         requestTimeoutMs: 1000,
@@ -116,9 +140,47 @@ describe("HTTP tests", () => {
       assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.HttpRequestFailure);
       assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Unexpected error occurred while trying to fetch config JSON.")));
 
+      assert.strictEqual(requestCount, 2);
+
       client.dispose();
     } finally {
       fetchMock.reset();
     }
   });
+
+  if (typeof AbortController !== "undefined") {
+    it("Abort on dispose", async () => {
+      const delayMs = 250;
+
+      let requestCount = 0;
+
+      fetchMock.get(
+        url => url.startsWith(baseUrl),
+        () => (++requestCount, delay(delayMs).then(() => ({ status: 200, body: "{}" })))
+      );
+
+      try {
+        const logger = new FakeLogger(LogLevel.Debug);
+
+        const client = platform.createClientWithManualPoll(sdkKey, {
+          requestTimeoutMs: 1000,
+          baseUrl,
+          logger,
+        });
+
+        const forceRefreshPromise = client.forceRefreshAsync();
+        await delay(delayMs / 5);
+        client.dispose();
+        const refreshResult = await forceRefreshPromise;
+
+        assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.UnexpectedError);
+        assert.include(refreshResult.errorMessage?.toString(), "Request was aborted.");
+        assert.isDefined(logger.events.find(([level, eventId, , err]) => level === LogLevel.Error && eventId === 1003 && errorToString(err).includes("Request was aborted.")));
+
+        assert.strictEqual(requestCount, 1);
+      } finally {
+        fetchMock.reset();
+      }
+    });
+  }
 });

--- a/test/chromium-extension/IndexTests.ts
+++ b/test/chromium-extension/IndexTests.ts
@@ -8,9 +8,11 @@ describe("ConfigCatClient index (main)", () => {
 
       const client: IConfigCatClient = configcatClient.getClient("SDKKEY-890123456789012/1234567890123456789012", pollingMode);
 
-      assert.isDefined(client);
-
-      client.dispose();
+      try {
+        assert.isDefined(client);
+      } finally {
+        client.dispose();
+      }
     });
   }
 

--- a/test/cloudflare-worker/IndexTests.ts
+++ b/test/cloudflare-worker/IndexTests.ts
@@ -8,9 +8,11 @@ describe("ConfigCatClient index (main)", () => {
 
       const client: IConfigCatClient = configcatClient.getClient("SDKKEY-890123456789012/1234567890123456789012", pollingMode);
 
-      assert.isDefined(client);
-
-      client.dispose();
+      try {
+        assert.isDefined(client);
+      } finally {
+        client.dispose();
+      }
     });
   }
 

--- a/test/deno/ClientTests.ts
+++ b/test/deno/ClientTests.ts
@@ -9,9 +9,11 @@ describe("ConfigCatClient tests", () => {
 
       const client: IConfigCatClient = configcatClient.getClient("SDKKEY-890123456789012/1234567890123456789012", pollingMode);
 
-      assert.isDefined(client);
-
-      client.dispose();
+      try {
+        assert.isDefined(client);
+      } finally {
+        client.dispose();
+      }
     });
   }
 

--- a/test/deno/HttpTests.ts
+++ b/test/deno/HttpTests.ts
@@ -1,0 +1,158 @@
+import { assert } from "chai";
+import fetchMock from "npm:fetch-mock";
+import { FakeLogger } from "../helpers/fakes";
+import { platform } from "../helpers/platform";
+import { LogLevel, RefreshErrorCode } from "#lib";
+import { getMonotonicTimeMs } from "#lib/Utils";
+
+const denoVersionComponents = Deno.version.deno.split(".");
+const denoMajorVersion = Number(denoVersionComponents[0]);
+const denoMinorVersion = Number(denoVersionComponents[1]);
+
+if (denoMajorVersion >= 2 || denoMajorVersion === 1 && denoMinorVersion >= 38) {
+  describe("HTTP tests", () => {
+    const sdkKey = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";
+    const baseUrl = "https://cdn-global.test.com";
+
+    it("HTTP timeout", async () => {
+      const requestTimeoutMs = 750;
+
+      let requestCount = 0;
+
+      fetchMock.get(
+        url => url.startsWith(baseUrl),
+        () => (++requestCount, new Promise(resolve => setTimeout(() => resolve({ throws: new Error("Test failed.") }), requestTimeoutMs * 4)))
+      );
+
+      try {
+        const logger = new FakeLogger(LogLevel.Debug);
+
+        const client = platform().createClientWithManualPoll(sdkKey, {
+          requestTimeoutMs,
+          baseUrl,
+          logger,
+        });
+        const startTime = getMonotonicTimeMs();
+        const refreshResult = await client.forceRefreshAsync();
+        const duration = getMonotonicTimeMs() - startTime;
+        // NOTE: Elapsed time is expected to be twice as `requestTimeoutMs` due to retry.
+        assert.isTrue(duration > 1000 && duration < 2000);
+
+        const defaultValue = "NOT_CAT";
+        assert.strictEqual(defaultValue, await client.getValueAsync("stringDefaultCat", defaultValue));
+
+        assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.HttpRequestTimeout);
+        assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Request timed out while trying to fetch config JSON.")));
+
+        assert.strictEqual(requestCount, 2);
+
+        client.dispose();
+      } finally {
+        fetchMock.reset();
+      }
+    });
+
+    it("404 Not found", async () => {
+      let requestCount = 0;
+
+      fetchMock.get(
+        url => url.startsWith(baseUrl),
+        () => (++requestCount, 404)
+      );
+
+      try {
+        const logger = new FakeLogger(LogLevel.Debug);
+
+        const client = platform().createClientWithManualPoll(sdkKey, {
+          requestTimeoutMs: 1000,
+          baseUrl,
+          logger,
+        });
+
+        const refreshResult = await client.forceRefreshAsync();
+
+        const defaultValue = "NOT_CAT";
+        assert.strictEqual(defaultValue, await client.getValueAsync("stringDefaultCat", defaultValue));
+
+        assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.InvalidSdkKey);
+        assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Your SDK Key seems to be wrong:")));
+
+        assert.strictEqual(requestCount, 1);
+
+        client.dispose();
+      } finally {
+        fetchMock.reset();
+      }
+    });
+
+    it("Unexpected status code", async () => {
+      let requestCount = 0;
+
+      fetchMock.get(
+        url => url.startsWith(baseUrl),
+        () => (++requestCount, 502)
+      );
+
+      try {
+        const logger = new FakeLogger(LogLevel.Debug);
+
+        const client = platform().createClientWithManualPoll(sdkKey, {
+          requestTimeoutMs: 1000,
+          baseUrl,
+          logger,
+        });
+
+        const refreshResult = await client.forceRefreshAsync();
+
+        const defaultValue = "NOT_CAT";
+        assert.strictEqual(defaultValue, await client.getValueAsync("stringDefaultCat", defaultValue));
+
+        assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.UnexpectedHttpResponse);
+        assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Unexpected HTTP response was received while trying to fetch config JSON:")));
+
+        assert.strictEqual(requestCount, 2);
+
+        client.dispose();
+      } finally {
+        fetchMock.reset();
+      }
+    });
+
+    it("Unexpected error", async () => {
+      let requestCount = 0;
+
+      fetchMock.get(
+        url => url.startsWith(baseUrl),
+        () => (++requestCount, { throws: new Error("Connection error.") })
+      );
+
+      try {
+        const logger = new FakeLogger(LogLevel.Debug);
+
+        const client = platform().createClientWithManualPoll(sdkKey, {
+          requestTimeoutMs: 1000,
+          baseUrl,
+          logger,
+        });
+
+        const refreshResult = await client.forceRefreshAsync();
+
+        const defaultValue = "NOT_CAT";
+        assert.strictEqual(defaultValue, await client.getValueAsync("stringDefaultCat", defaultValue));
+
+        assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.HttpRequestFailure);
+        assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Unexpected error occurred while trying to fetch config JSON.")));
+
+        assert.strictEqual(requestCount, 2);
+
+        client.dispose();
+      } finally {
+        fetchMock.reset();
+      }
+    });
+
+    // NOTE: For Deno, we skip the "Abort on dispose" test case as it fails with some weird "Uncaught (in promise)"
+    // error. This is probably related to the test runner (mocha) or fetch-mock because the test works as expected
+    // in a standalone console application.
+  });
+}

--- a/test/deno/HttpTests.ts
+++ b/test/deno/HttpTests.ts
@@ -3,7 +3,7 @@ import fetchMock from "npm:fetch-mock";
 import { FakeLogger } from "../helpers/fakes";
 import { platform } from "../helpers/platform";
 import { LogLevel, RefreshErrorCode } from "#lib";
-import { getMonotonicTimeMs } from "#lib/Utils";
+import { delay, errorToString, getMonotonicTimeMs } from "#lib/Utils";
 
 const denoVersionComponents = Deno.version.deno.split(".");
 const denoMajorVersion = Number(denoVersionComponents[0]);
@@ -151,8 +151,38 @@ if (denoMajorVersion >= 2 || denoMajorVersion === 1 && denoMinorVersion >= 38) {
       }
     });
 
-    // NOTE: For Deno, we skip the "Abort on dispose" test case as it fails with some weird "Uncaught (in promise)"
-    // error. This is probably related to the test runner (mocha) or fetch-mock because the test works as expected
-    // in a standalone console application.
+    it("Abort on dispose", async () => {
+      const delayMs = 250;
+
+      let requestCount = 0;
+
+      fetchMock.get(
+        url => url.startsWith(baseUrl),
+        () => (++requestCount, delay(delayMs).then(() => ({ status: 200, body: "{}" })))
+      );
+
+      try {
+        const logger = new FakeLogger(LogLevel.Debug);
+
+        const client = platform().createClientWithManualPoll(sdkKey, {
+          requestTimeoutMs: 1000,
+          baseUrl,
+          logger,
+        });
+
+        const forceRefreshPromise = client.forceRefreshAsync();
+        await delay(delayMs / 5);
+        client.dispose();
+        const refreshResult = await forceRefreshPromise;
+
+        assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.UnexpectedError);
+        assert.include(refreshResult.errorMessage?.toString(), "Request was aborted.");
+        assert.isDefined(logger.events.find(([level, eventId, , err]) => level === LogLevel.Error && eventId === 1003 && errorToString(err).includes("Request was aborted.")));
+
+        assert.strictEqual(requestCount, 1);
+      } finally {
+        fetchMock.reset();
+      }
+    });
   });
 }

--- a/test/deno/ServerSideFetchApiConfigFetcherTests.ts
+++ b/test/deno/ServerSideFetchApiConfigFetcherTests.ts
@@ -1,0 +1,103 @@
+import { assert } from "chai";
+import { platform } from "../helpers/platform";
+import { FetchRequest } from "#lib";
+import { CONFIGCAT_USER_AGENT_HEADER_NAME, getRequestHeaders } from "#lib/ConfigFetcher";
+import { ServerSideFetchApiConfigFetcher } from "#lib/deno";
+
+const testSdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g";
+const testETag = "W/\"123\"";
+
+describe("ServerSideFetchApiConfigFetcher tests", () => {
+  for (const [eTag, useCustomUrl, addCustomHeaders] of <[string | undefined, boolean, boolean][]>[
+    [void 0, false, false],
+    [void 0, false, true],
+    [void 0, true, false],
+    [void 0, true, true],
+    [testETag, false, false],
+    [testETag, false, true],
+    [testETag, true, false],
+    [testETag, true, true],
+  ]) {
+    it(`Should send user agent headers - eTag: ${eTag} | useCustomUrl: ${useCustomUrl} | addCustomHeaders: ${addCustomHeaders}`, async () => {
+      // Arrange
+
+      const timeoutMs = 15_000;
+
+      const capturedRequests: [url: string, headers: [string, string][] | undefined][] = [];
+
+      const extraHeaders: [string, string][] | undefined = addCustomHeaders
+        ? [
+          ["X-Custom", "1"],
+          [CONFIGCAT_USER_AGENT_HEADER_NAME, "x"],
+        ]
+        : void 0;
+
+      const configFetcher = new class extends ServerSideFetchApiConfigFetcher {
+        protected override setRequestHeaders(requestInit: { headers?: [string, string][] }, headers: ReadonlyArray<readonly [string, string]>): void {
+          super.setRequestHeaders(requestInit, extraHeaders ? [...headers, ...extraHeaders] : headers);
+        }
+      }();
+
+      configFetcher["fetchCoreAsync"] = function(...args: unknown[]) {
+        const url = args[0] as string;
+        const requestInit = args[1] as RequestInit & { headers?: [string, string][] };
+        capturedRequests.push([url, requestInit.headers]);
+        return { status: 200, statusText: "OK", headers: new Headers([]), text: () => Promise.resolve("{}") } as Response;
+      };
+
+      const options = platform().createManualPollOptions(testSdkKey);
+
+      const requestUrl = useCustomUrl
+        ? "http://example.com/configcat?x#y"
+        : options.getUrl();
+      const requestHeaders = getRequestHeaders(options.clientVersion);
+      const fetchRequest = new FetchRequest(requestUrl, eTag, requestHeaders, timeoutMs);
+
+      // Act
+
+      await configFetcher.fetchAsync(fetchRequest);
+
+      configFetcher.dispose();
+
+      // Assert
+
+      assert.equal(capturedRequests.length, 1);
+
+      const [[actualRequestUrl, actualRequestHeaders]] = capturedRequests;
+      assert.equal(actualRequestUrl, requestUrl);
+
+      const eTagHeaderValues: string[] = [];
+      if (actualRequestHeaders) {
+        for (const [key, value] of actualRequestHeaders) {
+          if (key.toLowerCase() === "if-none-match") {
+            eTagHeaderValues.push(value);
+          }
+        }
+      }
+
+      if (eTag) assert.deepEqual(eTagHeaderValues, [eTag]);
+      else assert.equal(eTagHeaderValues.length, 0);
+
+      const expectedHeaders: Record<string, string[]> = {};
+      for (const [key, value] of useCustomUrl && addCustomHeaders ? [...requestHeaders, ...extraHeaders!] : requestHeaders) {
+        const normalizedKey = key.toLowerCase();
+        let currentValues = expectedHeaders[normalizedKey];
+        if (!currentValues) currentValues = expectedHeaders[normalizedKey] = [];
+        currentValues.push(value);
+      }
+
+      const actualHeaders: Record<string, string[]> = {};
+      if (actualRequestHeaders) {
+        for (const [key, value] of actualRequestHeaders) {
+          const normalizedKey = key.toLowerCase();
+          if (eTag && normalizedKey === "if-none-match") continue;
+          let currentValues = actualHeaders[normalizedKey];
+          if (!currentValues) currentValues = actualHeaders[normalizedKey] = [];
+          currentValues.push(value);
+        }
+      }
+
+      assert.deepEqual(actualHeaders, expectedHeaders);
+    });
+  }
+});

--- a/test/helpers/ConfigLocation.ts
+++ b/test/helpers/ConfigLocation.ts
@@ -50,7 +50,7 @@ export class CdnConfigLocation extends ConfigLocation {
 
   getRealLocation(): string {
     const url = this.options.getUrl();
-    const index = url.lastIndexOf("?");
+    const index = url.indexOf("?");
     return index >= 0 ? url.slice(0, index) : url;
   }
 

--- a/test/helpers/ConfigLocation.ts
+++ b/test/helpers/ConfigLocation.ts
@@ -56,12 +56,15 @@ export class CdnConfigLocation extends ConfigLocation {
 
   async fetchConfigAsync(): Promise<Config> {
     const configService = new ManualPollConfigService(this.options);
-
-    const [fetchResult, projectConfig] = await configService.refreshConfigAsync();
-    if (!fetchResult.isSuccess) {
-      throw new Error("Could not fetch config from CDN: " + fetchResult.errorMessage);
+    try {
+      const [fetchResult, projectConfig] = await configService.refreshConfigAsync();
+      if (!fetchResult.isSuccess) {
+        throw new Error("Could not fetch config from CDN: " + fetchResult.errorMessage);
+      }
+      return projectConfig.config!;
+    } finally {
+      configService.dispose();
     }
-    return projectConfig.config!;
   }
 
   toString(): string {

--- a/test/helpers/platform.ts
+++ b/test/helpers/platform.ts
@@ -1,4 +1,4 @@
-import type { IAutoPollOptions, IConfigCatClient, IConfigCatConfigFetcher as IConfigFetcher, ILazyLoadingOptions, IManualPollOptions, IOptions, PollingMode } from "#lib";
+import type { IAutoPollOptions, IConfigCatClient, IConfigCatConfigFetcher as IConfigFetcher, ILazyLoadingOptions, IManualPollOptions, PollingMode } from "#lib";
 import { ConfigCatClient } from "#lib/ConfigCatClient";
 import { AutoPollOptions, LazyLoadOptions, ManualPollOptions } from "#lib/ConfigCatClientOptions";
 import type { IConfigCatKernel, OptionsBase } from "#lib/index.pubternals";

--- a/test/node/ClientTests.ts
+++ b/test/node/ClientTests.ts
@@ -12,9 +12,11 @@ describe("ConfigCatClient tests", () => {
 
       const client: IConfigCatClient = configcatClient.getClient("SDKKEY-890123456789012/1234567890123456789012", pollingMode);
 
-      assert.isDefined(client);
-
-      client.dispose();
+      try {
+        assert.isDefined(client);
+      } finally {
+        client.dispose();
+      }
     });
 
     it(`getClient() should set httpAgent and httpsAgent - ${PollingMode[pollingMode]}`, () => {
@@ -26,18 +28,20 @@ describe("ConfigCatClient tests", () => {
         httpsAgent,
       });
 
-      assert.isDefined(client);
+      try {
+        assert.isDefined(client);
 
-      const configService = (client as ConfigCatClient)["configService"];
-      if (!(configService instanceof ConfigServiceBase)) assert.fail();
+        const configService = (client as ConfigCatClient)["configService"];
+        if (!(configService instanceof ConfigServiceBase)) assert.fail();
 
-      const configFetcher = configService["configFetcher"];
-      assert.instanceOf(configFetcher, NodeHttpConfigFetcher);
+        const configFetcher = configService["configFetcher"];
+        assert.instanceOf(configFetcher, NodeHttpConfigFetcher);
 
-      assert.strictEqual(configFetcher["httpAgentState"], httpAgent);
-      assert.strictEqual(configFetcher["httpsAgentState"], httpsAgent);
-
-      client.dispose();
+        assert.strictEqual(configFetcher["httpAgentState"], httpAgent);
+        assert.strictEqual(configFetcher["httpsAgentState"], httpsAgent);
+      } finally {
+        client.dispose();
+      }
     });
   }
 

--- a/test/node/ClientTests.ts
+++ b/test/node/ClientTests.ts
@@ -34,8 +34,8 @@ describe("ConfigCatClient tests", () => {
       const configFetcher = configService["configFetcher"];
       assert.instanceOf(configFetcher, NodeHttpConfigFetcher);
 
-      assert.strictEqual(configFetcher["httpAgent"], httpAgent);
-      assert.strictEqual(configFetcher["httpsAgent"], httpsAgent);
+      assert.strictEqual(configFetcher["httpAgentState"], httpAgent);
+      assert.strictEqual(configFetcher["httpsAgentState"], httpsAgent);
 
       client.dispose();
     });

--- a/test/node/HttpTests.ts
+++ b/test/node/HttpTests.ts
@@ -9,7 +9,8 @@ import { LogLevel, RefreshErrorCode } from "#lib";
 import { delay, errorToString, getMonotonicTimeMs } from "#lib/Utils";
 
 // If the tests are failing with strange https or proxy errors, it is most likely that the local .key and .pem files are expired.
-// You can regenerate them anytime (./test/cert/regenerate.md).
+// You can regenerate them by following the instructions in `test/node/cert/regenerate.md`.
+
 describe("HTTP tests", () => {
   let server: mockttp.Mockttp;
   const sdkKey = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";

--- a/test/node/HttpTests.ts
+++ b/test/node/HttpTests.ts
@@ -31,13 +31,14 @@ describe("HTTP tests", () => {
     const logger = new FakeLogger();
 
     const client = platform.createClientWithManualPoll(sdkKey, {
-      requestTimeoutMs: 1000,
+      requestTimeoutMs: 750,
       baseUrl: server.url,
       logger,
     });
     const startTime = getMonotonicTimeMs();
     const refreshResult = await client.forceRefreshAsync();
     const duration = getMonotonicTimeMs() - startTime;
+    // NOTE: Elapsed time is expected to be twice as `requestTimeoutMs` due to retry.
     assert.isTrue(duration > 1000 && duration < 2000);
 
     const defaultValue = "NOT_CAT";
@@ -115,32 +116,35 @@ describe("HTTP tests", () => {
     client.dispose();
   });
 
-  it("HTTP proxy", async () => {
-    let proxyCallCount = 0;
+  for (const useAgentFactory of [false, true]) {
+    it(`HTTP proxy ${useAgentFactory ? "with" : "without"} agent factory`, async () => {
+      let proxyCallCount = 0;
 
-    server.forAnyRequest().forHost("cdn-global.configcat.com:443").thenPassThrough({
-      beforeRequest: (_: any) => {
-        proxyCallCount++;
-      },
+      server.forAnyRequest().forHost("cdn-global.configcat.com:443").thenPassThrough({
+        beforeRequest: (_: any) => {
+          proxyCallCount++;
+        },
+      });
+
+      const client = platform.createClientWithManualPoll(sdkKey, {
+        httpsAgent: !useAgentFactory ? new MockttpProxyAgent(server.url) : void 0,
+        httpsAgentFactory: useAgentFactory ? () => new MockttpProxyAgent(server.url) : void 0,
+      });
+
+      const refreshResult = await client.forceRefreshAsync();
+      assert.strictEqual(proxyCallCount, 1);
+
+      const defaultValue = "NOT_CAT";
+      assert.strictEqual("Cat", await client.getValueAsync("stringDefaultCat", defaultValue));
+
+      assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.None);
+
+      await client.forceRefreshAsync();
+      assert.strictEqual(proxyCallCount, 2);
+
+      client.dispose();
     });
-
-    const client = platform.createClientWithManualPoll(sdkKey, {
-      httpsAgent: new MockttpProxyAgent(server.url),
-    });
-
-    const refreshResult = await client.forceRefreshAsync();
-    assert.strictEqual(proxyCallCount, 1);
-
-    const defaultValue = "NOT_CAT";
-    assert.strictEqual("Cat", await client.getValueAsync("stringDefaultCat", defaultValue));
-
-    assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.None);
-
-    await client.forceRefreshAsync();
-    assert.strictEqual(proxyCallCount, 2);
-
-    client.dispose();
-  });
+  }
 });
 
 // NOTE: We need to augment the https.Agent type as some necessary methods are not defined in `@types/node`.

--- a/test/node/HttpTests.ts
+++ b/test/node/HttpTests.ts
@@ -6,7 +6,7 @@ import type { Duplex } from "stream";
 import { FakeLogger } from "../helpers/fakes";
 import { platform } from ".";
 import { LogLevel, RefreshErrorCode } from "#lib";
-import { getMonotonicTimeMs } from "#lib/Utils";
+import { delay, errorToString, getMonotonicTimeMs } from "#lib/Utils";
 
 // If the tests are failing with strange https or proxy errors, it is most likely that the local .key and .pem files are expired.
 // You can regenerate them anytime (./test/cert/regenerate.md).
@@ -26,9 +26,13 @@ describe("HTTP tests", () => {
   afterEach(() => server.stop());
 
   it("HTTP timeout", async () => {
-    server.forAnyRequest().thenTimeout();
+    let requestCount = 0;
 
-    const logger = new FakeLogger();
+    server.forAnyRequest()
+      .matching(() => (++requestCount, true))
+      .thenTimeout();
+
+    const logger = new FakeLogger(LogLevel.Debug);
 
     const client = platform.createClientWithManualPoll(sdkKey, {
       requestTimeoutMs: 750,
@@ -47,13 +51,19 @@ describe("HTTP tests", () => {
     assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.HttpRequestTimeout);
     assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Request timed out while trying to fetch config JSON.")));
 
+    assert.strictEqual(requestCount, 2);
+
     client.dispose();
   });
 
   it("404 Not found", async () => {
-    server.forAnyRequest().thenReply(404, "Not Found");
+    let requestCount = 0;
 
-    const logger = new FakeLogger();
+    server.forAnyRequest()
+      .matching(() => (++requestCount, true))
+      .thenReply(404, "Not Found");
+
+    const logger = new FakeLogger(LogLevel.Debug);
 
     const client = platform.createClientWithManualPoll(sdkKey, {
       requestTimeoutMs: 1000,
@@ -69,13 +79,19 @@ describe("HTTP tests", () => {
     assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.InvalidSdkKey);
     assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Your SDK Key seems to be wrong:")));
 
+    assert.strictEqual(requestCount, 1);
+
     client.dispose();
   });
 
   it("Unexpected status code", async () => {
-    server.forAnyRequest().thenReply(502, "Bad Gateway");
+    let requestCount = 0;
 
-    const logger = new FakeLogger();
+    server.forAnyRequest()
+      .matching(() => (++requestCount, true))
+      .thenReply(502, "Bad Gateway");
+
+    const logger = new FakeLogger(LogLevel.Debug);
 
     const client = platform.createClientWithManualPoll(sdkKey, {
       requestTimeoutMs: 1000,
@@ -91,13 +107,19 @@ describe("HTTP tests", () => {
     assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.UnexpectedHttpResponse);
     assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Unexpected HTTP response was received while trying to fetch config JSON:")));
 
+    assert.strictEqual(requestCount, 2);
+
     client.dispose();
   });
 
   it("Unexpected error", async () => {
-    server.forAnyRequest().thenCloseConnection();
+    let requestCount = 0;
 
-    const logger = new FakeLogger();
+    server.forAnyRequest()
+      .matching(() => (++requestCount, true))
+      .thenCloseConnection();
+
+    const logger = new FakeLogger(LogLevel.Debug);
 
     const client = platform.createClientWithManualPoll(sdkKey, {
       requestTimeoutMs: 1000,
@@ -112,6 +134,8 @@ describe("HTTP tests", () => {
 
     assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.HttpRequestFailure);
     assert.isDefined(logger.events.find(([level, , msg]) => level === LogLevel.Error && msg.toString().startsWith("Unexpected error occurred while trying to fetch config JSON.")));
+
+    assert.strictEqual(requestCount, 2);
 
     client.dispose();
   });
@@ -145,6 +169,38 @@ describe("HTTP tests", () => {
       client.dispose();
     });
   }
+
+  it("Abort on dispose", async () => {
+    const delayMs = 250;
+
+    let requestCount = 0;
+
+    server.forAnyRequest()
+      .matching(() => (++requestCount, true))
+      .thenCallback(async () => {
+        await delay(delayMs);
+        return { statusCode: 200, statusMessage: "OK", body: "{}" };
+      });
+
+    const logger = new FakeLogger(LogLevel.Debug);
+
+    const client = platform.createClientWithManualPoll(sdkKey, {
+      requestTimeoutMs: 1000,
+      baseUrl: server.url,
+      logger,
+    });
+
+    const forceRefreshPromise = client.forceRefreshAsync();
+    await delay(delayMs / 5);
+    client.dispose();
+    const refreshResult = await forceRefreshPromise;
+
+    assert.strictEqual(refreshResult.errorCode, RefreshErrorCode.UnexpectedError);
+    assert.include(refreshResult.errorMessage?.toString(), "Request was aborted.");
+    assert.isDefined(logger.events.find(([level, eventId, , err]) => level === LogLevel.Error && eventId === 1003 && errorToString(err).includes("Request was aborted.")));
+
+    assert.strictEqual(requestCount, 1);
+  });
 });
 
 // NOTE: We need to augment the https.Agent type as some necessary methods are not defined in `@types/node`.

--- a/test/node/NodeHttpConfigFetcherTests.ts
+++ b/test/node/NodeHttpConfigFetcherTests.ts
@@ -1,0 +1,646 @@
+import { assert } from "chai";
+import { EventEmitter } from "events";
+import * as http from "http";
+import * as https from "https";
+import type * as net from "net";
+import * as stream from "stream";
+import { FakeLogger } from "../helpers/fakes";
+import { platform } from ".";
+import { FetchError, FetchRequest, FetchResponse, LogLevel } from "#lib";
+import { LoggerWrapper } from "#lib/ConfigCatLogger";
+import { CONFIGCAT_USER_AGENT_HEADER_NAME, getRequestHeaders } from "#lib/ConfigFetcher";
+import { NodeHttpConfigFetcher } from "#lib/node";
+import { delay, isArray } from "#lib/Utils";
+
+const testSdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g";
+const testETag = "W/\"123\"";
+
+describe("NodeHttpConfigFetcher tests", () => {
+  for (const [runParallel, useHttps] of <[boolean, boolean][]>[
+    [false, false],
+    [false, true],
+    [true, false],
+    [true, true],
+  ]) {
+    it(`Should reuse internally managed agent on expected response - runParallel: ${runParallel} | useHttps: ${useHttps}`, async () => {
+      // Arrange
+
+      const timeoutMs = 15_000;
+
+      const logger = new LoggerWrapper(new FakeLogger(LogLevel.Debug));
+
+      const capturedParams: [FakeHttpAgent, timeoutMs: number | undefined][] = [];
+      let agentFactoryCallCount = 0;
+
+      const onRequest: FakeAgentOnRequest = function(options) {
+        capturedParams.push([this, options.timeout]);
+        return [{ statusCode: 304, statusMessage: "Not Modified", headers: { etag: testETag } }];
+      };
+
+      const configFetcher = new NodeHttpConfigFetcher(useHttps
+        ? { httpsAgentFactory: () => (++agentFactoryCallCount, new FakeHttpsAgent(onRequest)) }
+        : { httpAgentFactory: () => (++agentFactoryCallCount, new FakeHttpAgent(onRequest)) }
+      );
+
+      const options = platform.createManualPollOptions(testSdkKey);
+      let requestUrl = options.getUrl();
+      requestUrl = (useHttps ? "https" : "http") + requestUrl.substring(requestUrl.indexOf("://"));
+
+      const fetchRequest = new FetchRequest(requestUrl, testETag, [], timeoutMs);
+
+      // Act
+
+      if (runParallel) {
+        await Promise.all([
+          configFetcher["fetchInternalAsync"](fetchRequest, logger),
+          configFetcher["fetchInternalAsync"](fetchRequest, logger),
+        ]);
+      } else {
+        await configFetcher["fetchInternalAsync"](fetchRequest, logger);
+        await configFetcher["fetchInternalAsync"](fetchRequest, logger);
+      }
+
+      configFetcher.dispose();
+
+      // Assert
+
+      assert.strictEqual(capturedParams.length, 2);
+
+      const [[agent1, timeoutMs1], [agent2, timeoutMs2]] = capturedParams;
+
+      assert.strictEqual(agent2, agent1);
+      assert.strictEqual(timeoutMs1, timeoutMs);
+      assert.strictEqual(timeoutMs2, timeoutMs);
+
+      assert.strictEqual(agentFactoryCallCount, 1);
+    });
+  }
+
+  for (const [testCase, useHttps] of <["408" | "timeout" | "error", boolean][]>[
+    ["408", false],
+    ["408", true],
+    ["timeout", false],
+    ["timeout", true],
+    ["error", false],
+    ["error", true],
+  ]) {
+    it(`Should renew internally managed agent when response on unexpected response or failure - case: ${testCase} | useHttps: ${useHttps}`, async () => {
+      // Arrange
+
+      const timeoutMs = 500;
+
+      const logger = new LoggerWrapper(new FakeLogger(LogLevel.Debug));
+
+      const capturedParams: [FakeHttpAgent, timeoutMs: number | undefined][] = [];
+      let agentFactoryCallCount = 0;
+
+      let onRequest: FakeAgentOnRequest;
+      switch (testCase) {
+        case "408":
+          onRequest = function(options) {
+            capturedParams.push([this, options.timeout]);
+            return [{ statusCode: 408, statusMessage: "Request Timeout" }];
+          };
+          break;
+        case "timeout":
+          onRequest = function(options) {
+            capturedParams.push([this, options.timeout]);
+            return ["timeout", timeoutMs];
+          };
+          break;
+        case "error":
+          onRequest = function(options) {
+            capturedParams.push([this, options.timeout]);
+            return ["error"];
+          };
+          break;
+      }
+
+      const configFetcher = new NodeHttpConfigFetcher(useHttps
+        ? { httpsAgentFactory: () => (++agentFactoryCallCount, new FakeHttpsAgent(onRequest)) }
+        : { httpAgentFactory: () => (++agentFactoryCallCount, new FakeHttpAgent(onRequest)) }
+      );
+
+      const options = platform.createManualPollOptions(testSdkKey);
+      let requestUrl = options.getUrl();
+      requestUrl = (useHttps ? "https" : "http") + requestUrl.substring(requestUrl.indexOf("://"));
+
+      const fetchRequest = new FetchRequest(requestUrl, testETag, [], timeoutMs);
+
+      // Act
+
+      let fetchResponse: FetchResponse | undefined;
+      let fetchError: FetchError | undefined;
+      try {
+        fetchResponse = await configFetcher["fetchInternalAsync"](fetchRequest, logger);
+      } catch (err) {
+        if (!(err instanceof FetchError)) {
+          throw err;
+        }
+        fetchError = err;
+      }
+
+      configFetcher.dispose();
+
+      // Assert
+
+      switch (testCase) {
+        case "408":
+          assert.isDefined(fetchResponse);
+          assert.equal(fetchResponse.statusCode, 408);
+          break;
+        case "timeout":
+          assert.isDefined(fetchError);
+          assert.equal(fetchError.cause, "timeout");
+          break;
+        case "error":
+          assert.isDefined(fetchError);
+          assert.equal(fetchError.cause, "failure");
+          break;
+      }
+
+      assert.strictEqual(capturedParams.length, 2);
+
+      const [[agent1, timeoutMs1], [agent2, timeoutMs2]] = capturedParams;
+
+      assert.notStrictEqual(agent2, agent1);
+      assert.strictEqual(timeoutMs1, timeoutMs);
+      assert.strictEqual(timeoutMs2, timeoutMs);
+
+      assert.strictEqual(agentFactoryCallCount, 2);
+    });
+  }
+
+  for (const useHttps of [false, true]) {
+    it(`Should not renew internally managed agent after renew within threshold - useHttps: ${useHttps}`, async () => {
+      // Arrange
+
+      const timeoutMs = 500;
+      const agentRenewalThresholdMs = 1000;
+      const requestRetryDelayMs = 10;
+
+      const logger = new LoggerWrapper(new FakeLogger(LogLevel.Debug));
+
+      const capturedParams: [FakeHttpAgent, timeoutMs: number | undefined][] = [];
+      let agentFactoryCallCount = 0;
+
+      const onRequest: FakeAgentOnRequest = function(options) {
+        capturedParams.push([this, options.timeout]);
+        return ["error"];
+      };
+
+      const configFetcher = new NodeHttpConfigFetcher(useHttps
+        ? { httpsAgentFactory: () => (++agentFactoryCallCount, new FakeHttpsAgent(onRequest)) }
+        : { httpAgentFactory: () => (++agentFactoryCallCount, new FakeHttpAgent(onRequest)) }
+      );
+
+      configFetcher["agentRenewalThresholdMs"] = agentRenewalThresholdMs;
+      configFetcher["requestRetryDelayMs"] = requestRetryDelayMs;
+
+      const options = platform.createManualPollOptions(testSdkKey);
+      let requestUrl = options.getUrl();
+      requestUrl = (useHttps ? "https" : "http") + requestUrl.substring(requestUrl.indexOf("://"));
+
+      const fetchRequest = new FetchRequest(requestUrl, testETag, [], timeoutMs);
+
+      async function expectFetchError(action: () => Promise<void>) {
+        try {
+          await action();
+          assert.fail(`Expected ${FetchError.name}.`);
+        } catch (err) {
+          if (!(err instanceof FetchError && (err as FetchError).cause === "failure")) {
+            assert.fail(`Expected ${FetchError.name}.`);
+          }
+        }
+      }
+
+      // Act
+
+      await expectFetchError(() => configFetcher["fetchInternalAsync"](fetchRequest, logger));
+
+      await expectFetchError(() => configFetcher["fetchInternalAsync"](fetchRequest, logger));
+
+      await delay(agentRenewalThresholdMs * 3 / 2);
+
+      await expectFetchError(() => configFetcher["fetchInternalAsync"](fetchRequest, logger));
+
+      configFetcher.dispose();
+
+      // Assert
+
+      assert.strictEqual(capturedParams.length, 6);
+
+      const [
+        [agent1], [agent2], // 1st call to FetchAsync
+        [agent3], [agent4], // 2nd call to FetchAsync
+        [agent5], [agent6], // 3rd call to FetchAsync
+      ] = capturedParams;
+
+      assert.notStrictEqual(agent2, agent1);
+      assert.strictEqual(agent3, agent2);
+      assert.strictEqual(agent4, agent3);
+      assert.strictEqual(agent5, agent4);
+      assert.notStrictEqual(agent6, agent5);
+      assert.notStrictEqual(agent6, agent1);
+
+      assert.strictEqual(agentFactoryCallCount, 3);
+    });
+  }
+
+  for (const [testCase, useHttps] of <["200" | "408" | "timeout" | "error", boolean][]>[
+    ["200", false],
+    ["200", true],
+    ["408", false],
+    ["408", true],
+    ["timeout", false],
+    ["timeout", true],
+    ["error", false],
+    ["error", true],
+  ]) {
+    it(`Should use passed external agent - case: ${testCase} | useHttps: ${useHttps}`, async () => {
+      // Arrange
+
+      const timeoutMs = 500;
+      const body = "{}";
+
+      const logger = new LoggerWrapper(new FakeLogger(LogLevel.Debug));
+
+      const capturedParams: [FakeHttpAgent, timeoutMs: number | undefined][] = [];
+
+      let onRequest: FakeAgentOnRequest;
+      switch (testCase) {
+        case "200":
+          onRequest = function(options) {
+            capturedParams.push([this, options.timeout]);
+            return [{ statusCode: 200, statusMessage: "OK", headers: { etag: testETag }, body }];
+          };
+          break;
+        case "408":
+          onRequest = function(options) {
+            capturedParams.push([this, options.timeout]);
+            return [{ statusCode: 408, statusMessage: "Request Timeout" }];
+          };
+          break;
+        case "timeout":
+          onRequest = function(options) {
+            capturedParams.push([this, options.timeout]);
+            return ["timeout", timeoutMs];
+          };
+          break;
+        case "error":
+          onRequest = function(options) {
+            capturedParams.push([this, options.timeout]);
+            return ["error"];
+          };
+          break;
+      }
+
+      let agent: http.Agent | https.Agent;
+
+      const configFetcher = new NodeHttpConfigFetcher(useHttps
+        ? { httpsAgent: agent = new FakeHttpsAgent(onRequest) }
+        : { httpAgent: agent = new FakeHttpAgent(onRequest) }
+      );
+
+      const options = platform.createManualPollOptions(testSdkKey);
+      let requestUrl = options.getUrl();
+      requestUrl = (useHttps ? "https" : "http") + requestUrl.substring(requestUrl.indexOf("://"));
+
+      const fetchRequest = new FetchRequest(requestUrl, testETag, [], timeoutMs);
+
+      // Act
+
+      let fetchResponse: FetchResponse | undefined;
+      let fetchError: FetchError | undefined;
+      try {
+        fetchResponse = await configFetcher["fetchInternalAsync"](fetchRequest, logger);
+      } catch (err) {
+        if (!(err instanceof FetchError)) {
+          throw err;
+        }
+        fetchError = err;
+      }
+
+      configFetcher.dispose();
+
+      // Assert
+
+      switch (testCase) {
+        case "200":
+          assert.isDefined(fetchResponse);
+          assert.equal(fetchResponse.statusCode, 200);
+          assert.equal(fetchResponse.reasonPhrase, "OK");
+          assert.equal(fetchResponse.eTag, testETag);
+          assert.equal(fetchResponse.body, body);
+          break;
+        case "408":
+          assert.isDefined(fetchResponse);
+          assert.equal(fetchResponse.statusCode, 408);
+          break;
+        case "timeout":
+          assert.isDefined(fetchError);
+          assert.equal(fetchError.cause, "timeout");
+          break;
+        case "error":
+          assert.isDefined(fetchError);
+          assert.equal(fetchError.cause, "failure");
+          break;
+      }
+
+      assert.strictEqual(capturedParams.length, testCase !== "200" ? 2 : 1);
+
+      const [[agent1, timeoutMs1]] = capturedParams;
+
+      assert.strictEqual(agent1, agent);
+      assert.strictEqual(timeoutMs1, timeoutMs);
+
+      if (testCase !== "200") {
+        const [, [agent2, timeoutMs2]] = capturedParams;
+
+        assert.strictEqual(agent2, agent);
+        assert.strictEqual(timeoutMs2, timeoutMs);
+      }
+    });
+  }
+
+  for (const useHttps of [false, true]) {
+    it(`Should not destroy external agent - useHttps: ${useHttps}`, () => {
+      // Arrange
+
+      const onRequest: FakeAgentOnRequest = () => ["error"];
+      let agent: FakeHttpAgent | FakeHttpsAgent;
+
+      const configFetcher = new NodeHttpConfigFetcher(useHttps
+        ? { httpsAgent: agent = new FakeHttpsAgent(onRequest) }
+        : { httpAgent: agent = new FakeHttpAgent(onRequest) }
+      );
+
+      // Act
+
+      configFetcher.dispose();
+
+      // Assert
+
+      assert.isFalse(agent.destroyed);
+    });
+  }
+
+  for (const [eTag, useCustomUrl, addCustomHeaders] of <[string | undefined, boolean, boolean][]>[
+    [void 0, false, false],
+    [void 0, false, true],
+    [void 0, true, false],
+    [void 0, true, true],
+    [testETag, false, false],
+    [testETag, false, true],
+    [testETag, true, false],
+    [testETag, true, true],
+  ]) {
+    it(`Should send user agent headers - eTag: ${eTag} | useCustomUrl: ${useCustomUrl} | addCustomHeaders: ${addCustomHeaders}`, async () => {
+      // Arrange
+
+      const timeoutMs = 15_000;
+
+      const capturedRequests: [url: string, headers: Record<string, number | string | string[]> | undefined][] = [];
+
+      const extraHeaders: [string, string][] | undefined = addCustomHeaders
+        ? [
+          ["X-Custom", "1"],
+          [CONFIGCAT_USER_AGENT_HEADER_NAME, "x"],
+        ]
+        : void 0;
+
+      const configFetcher = new class extends NodeHttpConfigFetcher {
+        protected override setRequestHeaders(requestOptions: { headers?: Record<string, number | string | string[]> }, headers: ReadonlyArray<readonly [string, string]>): void {
+          super.setRequestHeaders(requestOptions, extraHeaders ? [...headers, ...extraHeaders] : headers);
+        }
+      }();
+
+      configFetcher["fetchCoreAsync"] = function(...args: unknown[]) {
+        const url = args[1] as string;
+        const requestOptions = args[2] as (http.RequestOptions | https.RequestOptions) & { headers?: Record<string, http.OutgoingHttpHeader> };
+        capturedRequests.push([url, requestOptions.headers]);
+        return new FetchResponse(200, "OK", [], "{}");
+      };
+
+      const options = platform.createManualPollOptions(testSdkKey);
+
+      const requestUrl = useCustomUrl
+        ? "http://example.com/configcat?x#y"
+        : options.getUrl();
+      const requestHeaders = getRequestHeaders(options.clientVersion);
+      const fetchRequest = new FetchRequest(requestUrl, eTag, requestHeaders, timeoutMs);
+
+      // Act
+
+      await configFetcher.fetchAsync(fetchRequest);
+
+      configFetcher.dispose();
+
+      // Assert
+
+      assert.equal(capturedRequests.length, 1);
+
+      const [[actualRequestUrl, actualRequestHeaders]] = capturedRequests;
+      assert.equal(actualRequestUrl, requestUrl);
+
+      const eTagHeaderValues: string[] = [];
+      if (actualRequestHeaders) {
+        for (const key of Object.keys(actualRequestHeaders)) {
+          if (key.toLowerCase() === "if-none-match") {
+            const value = actualRequestHeaders[key];
+            if (isArray(value)) eTagHeaderValues.push(...value);
+            else eTagHeaderValues.push(value + "");
+          }
+        }
+      }
+
+      if (eTag) assert.deepEqual(eTagHeaderValues, [eTag]);
+      else assert.equal(eTagHeaderValues.length, 0);
+
+      const expectedHeaders: Record<string, string[]> = {};
+      for (const [key, value] of useCustomUrl && addCustomHeaders ? [...requestHeaders, ...extraHeaders!] : requestHeaders) {
+        const normalizedKey = key.toLowerCase();
+        let currentValues = expectedHeaders[normalizedKey];
+        if (!currentValues) currentValues = expectedHeaders[normalizedKey] = [];
+        currentValues.push(value);
+      }
+
+      const actualHeaders: Record<string, string[]> = {};
+      if (actualRequestHeaders) {
+        for (const key of Object.keys(actualRequestHeaders)) {
+          const normalizedKey = key.toLowerCase();
+          if (eTag && normalizedKey === "if-none-match") continue;
+          const value = actualRequestHeaders[key];
+          let currentValues = actualHeaders[normalizedKey];
+          if (!currentValues) currentValues = actualHeaders[normalizedKey] = [];
+          if (isArray(value)) currentValues.push(...value);
+          else currentValues.push(value + "");
+        }
+      }
+
+      assert.deepEqual(actualHeaders, expectedHeaders);
+    });
+  }
+});
+
+type FakeAgentOnRequest = (this: FakeHttpAgent, options: http.RequestOptions) => FakeAgentOnRequestResult;
+
+type FakeAgentOnRequestResult = [FakeResponse | "abort" | "timeout" | "error", delayMs?: number];
+
+type FakeResponse = {
+  statusCode?: number;
+  statusMessage?: string;
+  headers?: http.IncomingHttpHeaders;
+  body?: string | Buffer;
+};
+
+/**
+ * Implements the minimal `http.Agent` interface for testing purposes without actual network connections.
+ */
+class FakeHttpAgent extends EventEmitter implements http.Agent {
+  maxSockets = Infinity;
+  maxFreeSockets = 256;
+  maxTotalSockets = Infinity;
+  scheduling = "lifo";
+  sockets = {};
+  freeSockets = {};
+  requests = {};
+
+  destroyed = false;
+
+  constructor(private readonly onRequest: FakeAgentOnRequest) {
+    super();
+  }
+
+  getName(options: http.RequestOptions): string {
+    return `${options.host}:${options.port ?? 80}`;
+  }
+
+  addRequest(req: http.ClientRequest, options: http.RequestOptions): void {
+    const [response, delayMs] = this.onRequest(options);
+
+    const endRequest = (options: http.RequestOptions, response: FakeAgentOnRequestResult[0]) => {
+      switch (response) {
+        case "abort":
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
+          req.aborted = true;
+          req.emit("close");
+          return;
+        case "timeout":
+          req.emit("timeout");
+          return;
+        case "error":
+          req.emit("error", Error("Network error."));
+          return;
+        default:
+          req.emit("response", new FakeIncomingMessage(options.method, response));
+      }
+    };
+
+    setTimeout(() => endRequest(options, response), delayMs ?? 0);
+  }
+
+  createConnection(): never {
+    throw Error("Not implemented.");
+  }
+
+  createSocket(): never {
+    throw Error("Not implemented.");
+  }
+
+  removeSocket(): never {
+    throw Error("Not implemented.");
+  }
+
+  keepSocketAlive(): false {
+    return false;
+  }
+
+  reuseSocket(): false {
+    return false;
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+  }
+}
+
+/**
+ * Implements the minimal `https.Agent` interface for testing purposes without actual network connections.
+ */
+class FakeHttpsAgent extends FakeHttpAgent implements https.Agent {
+  readonly options = {};
+
+  override addRequest(req: http.ClientRequest, options: http.RequestOptions): void {
+    if (typeof options.protocol === "undefined") {
+      options.protocol = "https:";
+    }
+    super.addRequest(req, options);
+  }
+}
+
+class FakeIncomingMessage extends stream.Readable implements http.IncomingMessage {
+  readonly httpVersion = "1.1";
+  readonly httpVersionMajor = 1;
+  readonly httpVersionMinor = 1;
+  complete = true;
+  get rawHeaders(): string[] { throw Error("Not supported."); }
+  get rawTrailers(): string[] { throw Error("Not supported."); }
+  trailers: { [key: string]: string | undefined } = {};
+  aborted = false;
+  upgrade = false;
+  get url(): string { throw Error("Not supported."); }
+  method: string | undefined = void 0;
+  statusCode: number | undefined = void 0;
+  statusMessage: string | undefined = void 0;
+  get socket(): any { throw Error("Not supported."); }
+  headers: http.IncomingHttpHeaders;
+  get connection(): net.Socket { throw Error("Not supported."); }
+
+  get headersDistinct(): Record<string, string[]> {
+    const result: Record<string, string[]> = {};
+    for (const key of Object.keys(this.headers)) {
+      const value = this.headers[key];
+      if (value) {
+        result[key] = Array.isArray(value) ? value : [value];
+      }
+    }
+    return result;
+  }
+
+  get trailersDistinct(): Record<string, string[]> {
+    return {};
+  }
+
+  constructor(method: string | undefined, response: FakeResponse) {
+    super();
+
+    this.method = method;
+    this.statusCode = response.statusCode ?? 200;
+    this.statusMessage = response.statusMessage ?? "OK";
+    this.headers = response.headers ?? {};
+
+    if (response.body) {
+      const bodyBuffer = typeof response.body === "string"
+        ? Buffer.from(response.body)
+        : response.body;
+
+      process.nextTick(() => {
+        this.emit("data", bodyBuffer);
+        this.emit("end");
+      });
+    } else {
+      process.nextTick(() => this.emit("end"));
+    }
+  }
+
+  setTimeout(msecs: number, callback?: () => void): this {
+    if (callback) {
+      this.once("timeout", callback);
+    }
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  override _read(size: number): void { }
+}


### PR DESCRIPTION
### Describe the purpose of your pull request

Improvements:
- Implements logic to retry failed HTTP requests one time (on receiving unexpected status code, timeout or request error).
- Deprecates the `httpAgent` and `httpsAgent` options for Node.js and Bun. Alternatives:  `httpAgentFactory` and `httpsAgentFactory`.
- Adds debug logging to built-in config fetcher implementations (`NodeHttpConfigFetcher`, `ClientSideFetchApiConfigFetcher`, `ServerSideFetchApiConfigFetcher` and `XmlHttpRequestConfigFetcher`). Also, enables logging for these even if they are created externally.
- Logs the CF-RAY header also when the headers are received but downloading the response body times out or fails.
- Improve handling of the case where the config fetcher gets disposed while a fetch operation is in progress. (The fetch operation, including pending HTTP requests, will be aborted.)
  - Ignore this case when it occurs in the background polling loop of Auto Polling mode.
  - Log it as an unexpected error when it happens during a user-initiated operation.
- Improve internal URL processing and manipulation to properly handle user-provided base URLs or fetch request URLs (those may contain query strings, URI-encoded characters, etc.)
- Revises other debug logging and eliminate redundancy to reduce bundle size.

Bug fixes:
- Fix bug that can lead to the process crashing on some runtimes like Node.js or Deno when an error is thrown and left unhandled during cache sync-up or config refresh.

Breaking changes:
- `FetchRequest.url` no longer includes query string parameters, only the path to the config JSON file. (If the SDK identifier string is needed, it can be obtained from `FetchRequest.headers`, by looking up the value for the `User-Agent` header.)
- `NodeHttpConfigFetcher` (used for Node.js and Bun) no longer use `http.globalAgent` and `https.globalAgent` for making HTTP requests, but create and manage own, internal agent instances.

Recommended reading:
* https://medium.com/@bhagyarana80/9-node-dns-caching-pitfalls-that-break-failover-plans-09206b48faab#0b53

### Related issues (only if applicable)
https://trello.com/c/bMad80Fm
https://trello.com/c/0KrZmHgQ
https://trello.com/c/zM7cDRqq

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
